### PR TITLE
[Overflow-167] Model, Migration and Seeder files for Questions

### DIFF
--- a/backend/app/Models/Question.php
+++ b/backend/app/Models/Question.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Question extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    const OPEN = 0;
+    const CLOSED = 1;
+    const DUPLICATE = 2;
+
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -4,14 +4,13 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -42,5 +41,10 @@ class User extends Authenticatable
     public function role()
     {
         return $this->belongsTo(Role::class);
+    }
+
+    public function questions()
+    {
+        return $this->hasMany(Question::class);
     }
 }

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -57,7 +57,7 @@ return [
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB',
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],

--- a/backend/database/factories/QuestionFactory.php
+++ b/backend/database/factories/QuestionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Question>
+ */
+class QuestionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        $userIds = DB::table('users')->pluck('id');
+
+        return [
+            'title' => fake()->sentence(),
+            'content' => fake()->paragraph(),
+            'user_id' => fake()->randomElement($userIds),
+        ];
+    }
+}

--- a/backend/database/migrations/2023_01_20_000000_create_users_table.php
+++ b/backend/database/migrations/2023_01_20_000000_create_users_table.php
@@ -22,7 +22,6 @@ return new class extends Migration
             $table->string('google_id')->unique()->nullable();
             $table->integer('reputation')->default(0);
             $table->timestamps();
-            $table->softDeletes();
 
             $table->foreignId('role_id')->nullable()->constrained()->nullOnDelete();
         });

--- a/backend/database/migrations/2023_01_23_014012_create_questions_table.php
+++ b/backend/database/migrations/2023_01_23_014012_create_questions_table.php
@@ -23,7 +23,7 @@ return new class extends Migration
             $table->timestamps();
             $table->softDeletes();
 
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained();
             // $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
         });
     }

--- a/backend/database/migrations/2023_01_23_014012_create_questions_table.php
+++ b/backend/database/migrations/2023_01_23_014012_create_questions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Question;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('questions', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->longText('content');
+            $table->integer('status')->default(Question::OPEN);
+            $table->boolean('is_public')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('questions');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -16,15 +16,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
-
         $this->call([
             RoleSeeder::class,
             PermissionSeeder::class,
             UserSeeder::class,
+            QuestionSeeder::class,
         ]);
     }
 }

--- a/backend/database/seeders/QuestionSeeder.php
+++ b/backend/database/seeders/QuestionSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Question;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class QuestionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Question::factory(20)->create();
+    }
+}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-167

## Commands
cd backend
php artisan migrate:fresh --seed

## Pre-conditions
Users and Roles tables should already have data rows.

## Expected Output
Questions table is now populated with dummy data. Deleting a user who owns question/s will also delete the question/s.

## Notes
Temporarily commented out `FK team_id` on the Question migration file, since it is not currently needed in this feature and causes errors if included. 

Also removed the `softDelete` property on Users to allow `cascadeOnDelete` on Users-Questions relationship

## Screenshots
<img width="273" alt="image" src="https://user-images.githubusercontent.com/116238730/213984297-fe685569-8228-4e61-8e70-c50659a61153.png">

_Deleting a user also deletes their question/s_
<img width="252" alt="image" src="https://user-images.githubusercontent.com/116238730/213984406-e5b1c61f-b66c-4e5a-866a-0e9a7b7fe6cb.png">
