### PR TITLE
[Overflow-32] [BE] Create API for Accepting Answer

### DIFF
--- a/backend/app/GraphQL/Mutations/AcceptAnswer.php
+++ b/backend/app/GraphQL/Mutations/AcceptAnswer.php
@@ -17,13 +17,17 @@ final class AcceptAnswer
         // TODO implement the resolver
         try {
             $question = Question::findOrFail($args['question_id']);
+
             $answer = Answer::findOrFail($args['answer_id']);
             $checkAccepted = $question->answers()->where('answers.is_correct', true)->exists();
+
             if($checkAccepted){
                 return "Only one answer can be accepted";
             }
+
             $answer->is_correct = true;
             $answer->save();
+
             return "Answer was accepted successfully";
 
         } catch (Exception $e) {

--- a/backend/app/GraphQL/Mutations/AcceptAnswer.php
+++ b/backend/app/GraphQL/Mutations/AcceptAnswer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use Exception;
+use App\Models\Answer;
+use App\Models\Question;
+
+final class AcceptAnswer
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        // TODO implement the resolver
+        try {
+            $question = Question::findOrFail($args['question_id']);
+            $answer = Answer::findOrFail($args['answer_id']);
+            $checkAccepted = $question->answers()->where('answers.is_correct', true)->exists();
+            if($checkAccepted){
+                return "Only one answer can be accepted";
+            }
+            $answer->is_correct = true;
+            $answer->save();
+            return "Answer was accepted successfully";
+
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+    }
+}

--- a/backend/graphql/answer/mutation.graphql
+++ b/backend/graphql/answer/mutation.graphql
@@ -7,7 +7,7 @@ extend type Mutation {
     updateAnswer(id: ID! @rules(apply: ["integer"]), content: String): Answer!
         @update
     acceptAnswer(
-        answer_id: ID! @rules(apply: ["integer"])
-        question_id: ID! @rules(apply: ["integer"])
+        answer_id: ID! @rules(apply: ["integer","required"])
+        question_id: ID! @rules(apply: ["integer","required])
     ): String! @field(resolver: "AcceptAnswer")
 }

--- a/backend/graphql/answer/mutation.graphql
+++ b/backend/graphql/answer/mutation.graphql
@@ -6,4 +6,8 @@ extend type Mutation {
     ): Answer!
     updateAnswer(id: ID! @rules(apply: ["integer"]), content: String): Answer!
         @update
+    acceptAnswer(
+        answer_id: ID! @rules(apply: ["integer"])
+        question_id: ID! @rules(apply: ["integer"])
+    ): String! @field(resolver: "AcceptAnswer")
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-32

## Commands

## Pre-conditions

## Expected Output
querying
```
mutation{
 acceptAnswer(question_id: {var} , answer_id: {var})
}
```
Should return in either `"Answer was accepted successfully"`, `"Only one answer can be accepted"`, or throw an error if either the question or answer does not exist
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/216496855-7ee3b80f-8640-45fb-be97-104ea1284004.png)
