### PR TITLE
[Overflow-27] [BUGFIX] Create and Update Comments API

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateComment.php
+++ b/backend/app/GraphQL/Mutations/CreateComment.php
@@ -15,23 +15,22 @@ final class CreateComment
      */
     public function __invoke($_, array $args)
     {
-        try {           
-            if($args['commentable_type'] == "Answer") {
+        try {
+            if ($args['commentable_type'] == "Answer") {
                 $commentable = Answer::findOrFail($args['commentable_id']);
             }
 
-            if($args['commentable_type'] == "Question") {
+            if ($args['commentable_type'] == "Question") {
                 $commentable = Question::findOrFail($args['commentable_id']);
             }
-            
+
             $comment = $commentable->comments()->create([
                 'content' => $args['content'],
                 'user_id' => Auth::id(),
             ]);
 
             return $comment;
-
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             return $e->getMessage();
         }
     }

--- a/backend/graphql/answer/mutation.graphql
+++ b/backend/graphql/answer/mutation.graphql
@@ -7,7 +7,7 @@ extend type Mutation {
     updateAnswer(id: ID! @rules(apply: ["integer"]), content: String): Answer!
         @update
     acceptAnswer(
-        answer_id: ID! @rules(apply: ["integer","required"])
-        question_id: ID! @rules(apply: ["integer","required])
+        answer_id: ID! @rules(apply: ["integer", "required"])
+        question_id: ID! @rules(apply: ["integer", "required"])
     ): String! @field(resolver: "AcceptAnswer")
 }

--- a/backend/graphql/comment/mutation.graphql
+++ b/backend/graphql/comment/mutation.graphql
@@ -1,7 +1,6 @@
 extend type Mutation {
     createComment(
-       content: String! @rules(apply: ["required"])
-        user_id: ID! @rules(apply: ["required", "integer"])
+        content: String! @rules(apply: ["required"])
         commentable_type: String! @rules(apply: ["required"])
         commentable_id: ID! @rules(apply: ["required", "integer"])
     ): Comment! @guard(with: ["api"])


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-27

## Commands
cd backend
php artisan migrate:fresh --seed

## Pre-conditions
none

## Expected Output
A user can create and update comments.

## Notes
Removed the `user_id` from `CreateComment` mutation

## Screenshots
<img width="575" alt="image" src="https://user-images.githubusercontent.com/116238730/216915695-6a0b2a0c-df18-480f-858c-0a71d4ad2a3a.png">
