### PR TITLE
[OVERFLOW-225] Update migration, model for Question && [OVERFLOW-226] Update API for get question for views count and slug

### DIFF
--- a/backend/app/GraphQL/Queries/Question.php
+++ b/backend/app/GraphQL/Queries/Question.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Question as ModelsQuestion;
+
+final class Question
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $question = ModelsQuestion::where('slug', $args["slug"])->first();
+
+        $question->update(["views_count" => $question->views_count + 1 ]);
+
+        return $question->fresh();
+    }
+}

--- a/backend/app/Models/Question.php
+++ b/backend/app/Models/Question.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Question extends Model
 {
@@ -17,6 +18,15 @@ class Question extends Model
     protected $guarded = [];
 
     protected $appends = ['vote_count','humanized_created_at'];
+
+    protected static function boot() 
+    {
+        parent::boot();
+
+        static::creating(function ($question) {
+            $question->slug = Str::slug($question->title);
+        });
+    }
 
     public function user()
     {

--- a/backend/database/migrations/2023_02_06_065010_add_slug_and_views_count_to_questions.php
+++ b/backend/database/migrations/2023_02_06_065010_add_slug_and_views_count_to_questions.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->string("slug");
+            $table->integer("views_count")->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropColumn('slug');
+            $table->dropColumn('views_count');
+        });
+    }
+};

--- a/backend/graphql/question/query.graphql
+++ b/backend/graphql/question/query.graphql
@@ -1,5 +1,5 @@
 extend type Query {
-    question(id: ID! @eq): Question @guard(with: ["api"]) @find 
+    question(slug: String! @eq): Question @guard(with: ["api"])
     questions(
         orderBy: _ @orderBy(columns: ["created_at"])
         filter: String

--- a/backend/graphql/question/type.graphql
+++ b/backend/graphql/question/type.graphql
@@ -2,6 +2,7 @@ type Question {
     id: ID!
     title: String!
     content: String!
+    slug: String!
     status: Int
     is_public: Boolean
     created_at: String!
@@ -9,6 +10,7 @@ type Question {
     updated_at: String
     deleted_at: String
     vote_count: Int
+    views_count: Int
     user: User! @belongsTo
     answers: [Answer!]! @hasMany
     comments: [Comment]! @morphMany


### PR DESCRIPTION
## Backlog Link
[SUN_OVERFLOW-225](https://framgiaph.backlog.com/view/SUN_OVERFLOW-225)
[SUN_OVERFLOW-226](https://framgiaph.backlog.com/view/SUN_OVERFLOW-226)
## Commands
`php artisan migrate` 
`php artisan db:seed --class=QuestionSeeder`
## Pre-conditions
none
## Expected Output
- Slug is now used to find question.
- When requesting Question detail api views are incremented.
- slug and views_count are added in query for Question
## Notes
None
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/216919596-214275b2-93f4-43e2-bfe0-9b867004e187.png)
![image](https://user-images.githubusercontent.com/116168014/216919887-4990cd1f-3ddc-4a47-8d08-afa779fa3c11.png)
