### PR TITLE
[OVERFLOW-227] [FE] Implement API to Question detail Page

### DIFF
--- a/frontend/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/components/organisms/QuestionDetail/index.tsx
@@ -1,8 +1,10 @@
+import 'react-quill/dist/quill.core.css';
 import Icons from '@/components/atoms/Icons'
 import Avatar from '@/components/molecules/Avatar'
 import Bookmark from '@/components/molecules/Bookmark'
 import Tags from '@/components/molecules/Tags'
 import Votes from '@/components/molecules/Votes'
+import { parseHTML } from '@/helpers/htmlParsing'
 import Link from 'next/link'
 import { Fragment } from 'react'
 import AnswerComponent from '../AnswerComponent'
@@ -56,8 +58,8 @@ const QuestionDetail = ({
                             </div>
                         </div>
                         <div className="flex w-full flex-col justify-between gap-3">
-                            <div className="flex w-full flex-col gap-3">
-                                <div className="w-full">{content}</div>
+                            <div className="flex w-full flex-col gap-3 ql-snow">
+                                <div className="w-full ql-editor">{parseHTML(content)}</div>
                                 <div className="w-full">
                                     <Tags values={tags} />
                                 </div>

--- a/frontend/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/components/organisms/QuestionDetail/index.tsx
@@ -12,7 +12,7 @@ type QuestionDetailProps = {
   title: string;
   content: string;
   created_at: string;
-  view_count: number;
+  views_count: number;
   vote_count: number;
   tags: { id: number; name: string; is_watched_by_user: boolean }[];
   user: { id: number; first_name: string; last_name: string; avatar: string };
@@ -24,7 +24,7 @@ const QuestionDetail = ({
     title,
     content,
     created_at,
-    view_count,
+    views_count,
     vote_count,
     tags,
     user,
@@ -45,7 +45,7 @@ const QuestionDetail = ({
                         </div>
                         <div className="flex gap-1">
                             <span>Viewed</span>
-                            <span className="text-gray-500">{view_count} times</span>
+                            <span className="text-gray-500">{views_count} times</span>
                         </div>
                     </div>
                     <div className="flex w-full flex-row">

--- a/frontend/helpers/graphql/queries/get_question.ts
+++ b/frontend/helpers/graphql/queries/get_question.ts
@@ -1,13 +1,15 @@
 import { gql } from "@apollo/client";
 
 const GET_QUESTION = gql`
- query getQuestion($id : ID!) {
-    question(id : $id) {
+ query getQuestion($slug : String!) {
+    question(slug : $slug) {
         id
         title
         content
         created_at
+        slug
         vote_count
+        views_count
         humanized_created_at
         tags {
             id

--- a/frontend/helpers/htmlParsing.tsx
+++ b/frontend/helpers/htmlParsing.tsx
@@ -1,0 +1,5 @@
+import parse from 'html-react-parser';
+
+export function parseHTML(htmlString: string = '<div><div/>') {
+    return parse(htmlString);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "eslint": "8.32.0",
         "eslint-config-next": "13.1.2",
         "graphql": "^16.6.0",
+        "html-react-parser": "^3.0.8",
         "i": "^0.3.7",
         "next": "13.1.2",
         "next-auth": "^4.18.9",

--- a/frontend/pages/questions/[slug].tsx
+++ b/frontend/pages/questions/[slug].tsx
@@ -3,6 +3,7 @@ import Comment from '@/components/organisms/Comment'
 import QuestionDetail from '@/components/organisms/QuestionDetail'
 import GET_QUESTION from '@/helpers/graphql/queries/get_question'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
+import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { Fragment } from 'react'
@@ -13,14 +14,14 @@ const QuestionDetailPage = () => {
 
     const { data, loading, error} = useQuery(GET_QUESTION, {
         variables :{
-            id: Number(query.id),
+            slug: String(query.slug),
         }
     });
 
     if(loading) 
         return loadingScreenShow();
     else if (error)
-        return `Error! ${error}`;
+        return errorNotify(`Error! ${error}`);
 
     const question: {
         id: number
@@ -28,15 +29,13 @@ const QuestionDetailPage = () => {
         content: string
         created_at: string
         vote_count: number
-        view_count: number
+        views_count: number
         tags: { id: number; name: string; is_watched_by_user: boolean }[]
         is_bookmark: boolean
         user: { id: number; first_name: string; last_name: string; avatar: string }
     } = {
         ...data.question,
         created_at : data.question.humanized_created_at,
-        view_count : 23,  // to be added in new API and Task
-        is_bookmark : false // to be added in new API and Task
     }
 
     const answer: {
@@ -72,7 +71,7 @@ const QuestionDetailPage = () => {
                     content={question.content}
                     created_at={question.created_at}
                     vote_count={question.vote_count}
-                    view_count={question.view_count}
+                    views_count={question.views_count}
                     tags={question.tags}
                     is_bookmark={question.is_bookmark}
                     user={question.user}


### PR DESCRIPTION
## Backlog Link
[SUN_OVERFLOW-227](https://framgiaph.backlog.com/view/SUN_OVERFLOW-227)
## Commands
None
## Pre-conditions
None
## Expected Output
Question detail page should now be working for slug and display dynamic views count
## Notes
None
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/217143541-8c5fa1bd-81d3-4742-8855-589e7ef888ec.png)
