### PR TITLE
[OVERFLOW-156] Update yml and added custom commands

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Load Environment Variables
         run: cd backend && php -r "file_exists('.env') || copy('.env.example', '.env');"
       - name: Install Dependencies
-        run: cd backend && composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+        run: cd backend && composer update && composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
       - name: Composer Generate Key
         run: cd backend && php artisan key:generate
       - name: Run PSR2 Code Checker

--- a/backend/app/Console/Commands/CodeSniffer.php
+++ b/backend/app/Console/Commands/CodeSniffer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+class CodeSniffer extends Command
+{
+    protected $signature = 'code:sniffer';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will run PHP Code Sniffer to check laravel codes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $process = new Process([
+            './vendor/bin/phpcs',
+            '--colors',
+            '--report=full',
+            '--exclude=PSR1.Methods.CamelCapsMethodName',
+            '--standard=PSR2',
+            './app',
+            './config',
+            './database',
+            './routes',
+            './tests',
+        ]);
+
+        $process->run();
+
+        echo $process->getOutput();
+    }
+}

--- a/backend/app/Console/Commands/PintFormatting.php
+++ b/backend/app/Console/Commands/PintFormatting.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+class PintFormatting extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'code:pint {directory?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will run laravel PINT';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $process = new Process(['./vendor/bin/pint', $this->argument('directory')]);
+
+        $process->run();
+
+        echo $process->getOutput();
+    }
+}

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -29,7 +29,6 @@ abstract class TestCase extends BaseTestCase
                     if ($this->schemaGrammar === null) {
                         $this->useDefaultSchemaGrammar();
                     }
-
                     return new class($this) extends SQLiteBuilder
                     {
                         protected function createBlueprint($table, Closure $callback = null)

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -29,6 +29,7 @@ abstract class TestCase extends BaseTestCase
                     if ($this->schemaGrammar === null) {
                         $this->useDefaultSchemaGrammar();
                     }
+
                     return new class($this) extends SQLiteBuilder
                     {
                         protected function createBlueprint($table, Closure $callback = null)


### PR DESCRIPTION
## Backlog Link
[SUN_OVERFLOW-156](https://framgiaph.backlog.com/view/SUN_OVERFLOW-156)
## Commands
`cd backend`
`composer install`
`composer dump-autoload`
`php artisan code:sniffer`
`php artisan code:pint`
## Pre-conditions
None
## Expected Output
You can use the `php artisan code:sniffer` to run PHPCS
You can now use `php artisan code:pint` to run Laravel PINT for code formatting
## Notes
None
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/218016391-daf8aed3-25de-4509-bc7a-c376b7b7024a.png)
![image](https://user-images.githubusercontent.com/116168014/218016439-0444f675-6820-4c9b-b164-0080f4eba841.png)
