### PR TITLE
[Overflow-61] Create API for retrieving bookmark

### DIFF
--- a/backend/app/GraphQL/Queries/Bookmarks.php
+++ b/backend/app/GraphQL/Queries/Bookmarks.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\Bookmark;
+use Exception;
+
+final class Bookmarks
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $query = Bookmark::query();
+
+        try {
+            if ($args['filter'] == 'Question') {
+                $query->where('bookmarkable_type', 'App\Models\Question');
+            }
+
+            if ($args['filter'] == 'Answer') {
+                $query->where('bookmarkable_type', 'App\Models\Answer');
+            }
+
+            return $query;
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+    }
+}

--- a/backend/graphql/bookmark/query.graphql
+++ b/backend/graphql/bookmark/query.graphql
@@ -1,0 +1,9 @@
+extend type Query {
+    bookmark(id: ID! @eq): Bookmark @find
+    bookmarks(
+        orderBy: _ @orderBy(columns: ["created_at"])
+        filter: String = null
+    ): [Bookmark!]!
+        @guard(with: ["api"])
+        @paginate(builder: "App\\GraphQL\\Queries\\Bookmarks")
+}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-61
## Commands
```
query Bookmarks {
  bookmarks(
    orderBy: [{column: CREATED_AT, order: DESC}],
    first: 10
    filter: "Question"
  ){
    data{
    	id
    	created_at
    	updated_at
    	user {
    		id
  		}
    	bookmarkable {
      	__typename
    	}
    }
  paginatorInfo {
    currentPage
    count
    perPage
    hasMorePages
    total
  	}
  }
}
```
## Pre-conditions

## Expected Output
Created an API for retrieving bookmarked Question and answer
Result has the identifier if what is the Type of the bookmark (Question or answer)
## Notes

## Screenshots
return all bookmarked queries (Question and Answer)
![15 02 2023_16 59 27_REC](https://user-images.githubusercontent.com/49836629/218981377-0eeb97f7-62bb-4558-8438-6fe4ce42f79e.png)

return all Answer bookmarked queries
![15 02 2023_16 59 45_REC](https://user-images.githubusercontent.com/49836629/218981580-40aac1b7-26d0-49f4-9aeb-78412b91c17c.png)

return all Question bookmarked queries
![15 02 2023_17 00 02_REC](https://user-images.githubusercontent.com/49836629/218981638-02c97441-4446-4008-af41-d6ad8e8aeff5.png)
