### PR TITLE
[Overflow-59] [Overflow-60] [BE] Retrieve User API

### DIFF
--- a/backend/app/GraphQL/Mutations/AcceptAnswer.php
+++ b/backend/app/GraphQL/Mutations/AcceptAnswer.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\Answer;
 use App\Models\Question;
+use App\Models\User;
 use Exception;
 
 final class AcceptAnswer
@@ -27,6 +28,10 @@ final class AcceptAnswer
 
             $answer->is_correct = true;
             $answer->save();
+
+            $user = User::find($answer->user_id);
+            $user->reputation += 1;
+            $user->save();
 
             return 'Answer was accepted successfully';
         } catch (Exception $e) {

--- a/backend/app/GraphQL/Mutations/UpsertVote.php
+++ b/backend/app/GraphQL/Mutations/UpsertVote.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\Answer;
 use App\Models\Question;
+use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -40,6 +41,12 @@ final class UpsertVote
                     ['user_id' => Auth::id()],
                     ['value' => $args['value']]
                 );
+
+                $user = User::find($voteable->user_id);
+                $user->reputation += $args['value'];
+                if ($user->reputation >= 0) {
+                    $user->save();
+                }
 
                 return 'Voted Successfully';
             }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -22,6 +22,8 @@ class User extends Authenticatable
      */
     protected $guarded = [];
 
+    protected $appends = ['question_count', 'answer_count', 'top_questions', 'top_answers'];
+
     /**
      * The attributes that should be hidden for serialization.
      *
@@ -98,5 +100,33 @@ class User extends Authenticatable
     public function answers()
     {
         return $this->hasMany(Answer::class);
+    }
+
+    public function getQuestionCountAttribute()
+    {
+        return $this->questions()->count();
+    }
+
+    public function getAnswerCountAttribute()
+    {
+        return $this->answers()->count();
+    }
+
+    public function getTopQuestionsAttribute()
+    {
+        return $this->questions->where('vote_count', '>', 0)->sortByDesc(function ($question) {
+            return $question->votes->sum('value');
+        })->take(5)->map(function ($q) {
+            return $q->fresh();
+        });
+    }
+
+    public function getTopAnswersAttribute()
+    {
+        return $this->answers->where('vote_count', '>', 0)->sortByDesc(function ($answer) {
+            return $answer->votes->sum('value');
+        })->take(5)->map(function ($a) {
+            return $a->fresh();
+        });
     }
 }

--- a/backend/graphql/user/type.graphql
+++ b/backend/graphql/user/type.graphql
@@ -6,13 +6,20 @@ type User {
     email: String!
     google_id: String
     reputation: Int!
+    slug: String!
+    about_me: String
     created_at: String!
     updated_at: String
+    question_count: Int
+    answer_count: Int
+    top_questions: [Question]
+    top_answers: [Answer]
     role: Role! @belongsTo
     watchedTags: [Tag!]! @belongsToMany
     questions: [Question!]! @hasMany
     answers: [Answer!]! @hasMany
     comments: [Comment!]! @hasMany
+    bookmarks: [Bookmark!]! @hasMany(type: PAGINATOR, defaultCount: 5)
     notifications: [UserNotification!]! @hasMany
     teams: [Member!]! @hasMany
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-59
https://framgiaph.backlog.com/view/SUN_OVERFLOW-60

## Commands
On `http://localhost:8000/graphiql`:
```
query User {
  user(id: 21) {
    id
    first_name
    last_name
    avatar
    email
    reputation
    id
    slug
    about_me
    question_count
    answer_count
    bookmarks {
      data {
        id
        bookmarkable {
          __typename
        }
      }
      paginatorInfo {
        currentPage
        count
      }
    }
    watchedTags {
      id
      name
    }
    top_questions {
      id
      title
      vote_count
    }
    top_answers {
      id
      vote_count
    }
  }
}
```

## Pre-conditions
none

## Expected Output
User details can be retrieved along with the ff:
- question count
- answer count
- paginated list of bookmarks
- watched tags
- top activity (top 5 most voted questions and answers)

## Notes
- `Overflow-60 | Create API for retrieving user activities` is included in the query (user's top activity)
- Also updated Accept Answer and Vote mutations to be added to a user's reputation.

## Screenshots
<img width="821" alt="image" src="https://user-images.githubusercontent.com/116238730/219297284-d8747500-a97c-4f21-a7d5-08232f7f4e90.png">
