### PR TITLE
[Overflow-248] [Bugfix] Move RightSideBar to the Page itself and not …

### DIFF
--- a/frontend/components/atoms/ProfileImage/index.tsx
+++ b/frontend/components/atoms/ProfileImage/index.tsx
@@ -10,8 +10,8 @@ interface ProfileImageProps {
 const ProfileImage = ({ first_name, last_name, avatar }: ProfileImageProps) => {
     return (
         <Fragment>
-            <div className="relative flex place-content-center">
-                <div className="relative aspect-square w-3/5">
+            <div className="relative flex place-content-center ">
+                <div className="relative aspect-square">
                     <Avatar
                         round={true}
                         name={`${first_name} ${last_name}`}
@@ -23,7 +23,7 @@ const ProfileImage = ({ first_name, last_name, avatar }: ProfileImageProps) => {
                     />
                 </div>
             </div>
-            <div className="mt-6 ml-6 flex px-6 text-center text-2xl font-semibold line-clamp-3">
+            <div className="mt-6 flex px-6 text-center text-2xl font-semibold line-clamp-3">
                 {first_name} {last_name}
             </div>
         </Fragment>

--- a/frontend/components/organisms/Sidebar/RightSideBar.tsx
+++ b/frontend/components/organisms/Sidebar/RightSideBar.tsx
@@ -5,7 +5,7 @@ import { LOAD_SIDEBAR_1, LOAD_SIDEBAR_2, LOAD_SIDEBAR_3 } from '@/helpers/graphq
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 type TRightSidebarProps = {
-    usage: string
+    usage: null | 'teams' | 'users'
 }
 const RightSideBar = ({ usage }: TRightSidebarProps) => {
     if (usage === 'teams') {

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -10,7 +10,11 @@ type LayoutProps = {
 
 const Layout = ({ children }: LayoutProps) => {
     const router = useRouter()
-    const hideRightSidebarInPages: string[] = ['/questions/[slug]', '/questions/add']
+    const hideRightSidebarInPages: string[] = [
+        '/questions/[slug]',
+        '/questions/add',
+        '/users/[slug]',
+    ]
 
     const routeIfLoginPathCheck = router.asPath === '/login' || router.asPath === '/login/check'
     return (

--- a/frontend/pages/users/[slug].tsx
+++ b/frontend/pages/users/[slug].tsx
@@ -9,6 +9,7 @@ import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import { RightSideBar } from '@/components/organisms/Sidebar'
 
 export type ProfileType = {
     id: number
@@ -26,7 +27,6 @@ const ProfilePage = () => {
 
     const router = useRouter()
     const query = router.query
-
     const { data, loading, error, refetch } = useQuery(GET_USER, {
         variables: {
             slug: query.slug,
@@ -37,6 +37,10 @@ const ProfilePage = () => {
         refetch()
     }, [router, refetch])
 
+    useEffect(() => {
+        console.log(data)
+    }, [data])
+
     if (loading) return loadingScreenShow()
     else if (error) return errorNotify(`Error! ${error}`)
 
@@ -45,30 +49,33 @@ const ProfilePage = () => {
     }
 
     return (
-        <div className="flex h-full flex-col">
-            <div className="mt-10 flex h-auto w-full flex-row ">
-                <div className="ml-6 flex w-1/3 flex-col ">
+        <div className="mx-8 mt-10 flex h-full w-full flex-col">
+            <div className="flex h-auto w-full flex-row ">
+                <div className="ml-6 flex w-1/6 flex-col ">
                     <ProfileImage
                         first_name={profile.first_name}
                         last_name={profile.last_name}
                         avatar={profile.avatar}
                     />
                 </div>
-                <div className="flex w-3/4 flex-col">
+                <div className="mx-10 flex w-1/2 flex-col">
                     <AboutMe
                         about_me={profile.about_me}
                         authenticated_user_id={user_id}
                         user_id={profile.id}
                     />
                 </div>
+                <div className="mr-10 flex grow">
+                    {user_id == Number(data.user.id) && <RightSideBar usage="users" />}
+                </div>
             </div>
             <div className="my-4 flex w-full flex-row ">
-                <div className="ml-10 flex w-1/3 justify-center ">
+                <div className=" mr-20 ml-6 flex w-1/6 justify-center bg-blue-100 px-6">
                     <Button type="button" usage="follow" additionalClass="my-auto drop-shadow-xl">
                         Follow
                     </Button>
                 </div>
-                <div className="ml-12 flex w-2/3 ">
+                <div className=" flex w-1/2 px-8 ">
                     <div className="flex w-full flex-row self-end">
                         <ProfileStats value={profile.reputation} text="Reputation" />
                         <ProfileStats value={profile.question_count} text="Questions" />
@@ -78,8 +85,8 @@ const ProfilePage = () => {
                     </div>
                 </div>
             </div>
-            <div className="mt-3 ml-6 flex h-3/5 flex-col">
-                <ul className="h-1/10 ml-10 flex w-[129%] flex-row border-b-2 border-gray-300">
+            <div className="mt-3 flex h-3/5 flex-col">
+                <ul className="h-1/10 ml-10 flex w-[95%] flex-row border-b-2 border-gray-300">
                     <li className="">
                         <div className="-mb-[1px] border-b-2 border-b-primary-red bg-red-100 px-6 font-semibold">
                             Activity

--- a/frontend/pages/users/[slug].tsx
+++ b/frontend/pages/users/[slug].tsx
@@ -70,7 +70,7 @@ const ProfilePage = () => {
                 </div>
             </div>
             <div className="my-4 flex w-full flex-row ">
-                <div className=" mr-20 ml-6 flex w-1/6 justify-center bg-blue-100 px-6">
+                <div className=" mr-20 ml-6 flex w-1/6 justify-center">
                     <Button type="button" usage="follow" additionalClass="my-auto drop-shadow-xl">
                         Follow
                     </Button>


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-248
## Commands

## Pre-conditions

## Expected Output
Right Sidebar in Layout should hide when viewing profile page
A Watched Tag Component is in the Profile Page itself

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/220017721-db7f8be0-3840-4268-924f-23a299cfb01b.png)
![image](https://user-images.githubusercontent.com/114897466/220017766-f6ebfdf5-52ee-4f74-9791-e1273163b979.png)
