### PR TITLE
[Overflow-51] [FE] Integrate API to search form and users page

### DIFF
--- a/frontend/components/molecules/NotificationDropdown/index.tsx
+++ b/frontend/components/molecules/NotificationDropdown/index.tsx
@@ -194,6 +194,7 @@ const setAvatar = (notifiable: any): JSX.Element => {
             alt={setName(notifiable)}
             src={avatar}
             maxInitials={1}
+            textSizeRatio={2}
         />
     )
 }

--- a/frontend/components/molecules/SearchInput/index.tsx
+++ b/frontend/components/molecules/SearchInput/index.tsx
@@ -3,9 +3,11 @@ import Icons from '@/components/atoms/Icons'
 type Props = {
     placeholder?: string
     usage?: 'Default' | 'Users'
+    value?: string
+    onChange: (value: string) => void
 }
 
-const SearchInput = ({ placeholder, usage = 'Default' }: Props): JSX.Element => {
+const SearchInput = ({ placeholder, value, usage = 'Default', onChange }: Props): JSX.Element => {
     const divStyle = {
         Default: 'relative flex w-80 flex-row',
         Users: 'relative flex w-80 flex-row',
@@ -26,6 +28,8 @@ const SearchInput = ({ placeholder, usage = 'Default' }: Props): JSX.Element => 
                 name="search"
                 className={`${inputStyle[usage]} pr-10`}
                 placeholder={placeholder}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
             />
             <button type="submit" className={buttonStyle[usage]}>
                 <Icons name="search_input_icon" />

--- a/frontend/components/molecules/UserTab/index.tsx
+++ b/frontend/components/molecules/UserTab/index.tsx
@@ -1,15 +1,18 @@
 import Link from 'next/link'
 import { isObjectEmpty } from '@/utils'
-import Image from 'next/image'
 import Avatar from 'react-avatar'
 
-interface IUser {
+export interface IUser {
     id: number
     first_name: string
     last_name: string
     avatar: string
     reputation: number
-    role: string
+    role: {
+        id: number
+        name: string
+    }
+    slug: string
 }
 
 interface UserTabProps {
@@ -38,7 +41,7 @@ const UserTab = ({ user, usage }: UserTabProps) => {
         return (
             <Link
                 className={`text-overflow-ellipsis flex  w-full items-center overflow-hidden  hover:bg-[#E8E8E8] ${cardStyle[usage]}`}
-                href={`/user/${user.id}`}
+                href={`/users/${user.slug}`}
             >
                 <Avatar
                     round={true}
@@ -54,7 +57,7 @@ const UserTab = ({ user, usage }: UserTabProps) => {
                     <div className={nameStyle[usage]}>
                         {user.first_name} {user.last_name}
                     </div>
-                    <div className={roleStyle[usage]}>{user.role}</div>
+                    <div className={roleStyle[usage]}>{user.role.name}</div>
                     <div className="hidden  lg:flex">
                         {usage === 'UserList' ? (
                             <div className="text-md font-bold">{user.reputation} pts</div>

--- a/frontend/components/molecules/UserTab/index.tsx
+++ b/frontend/components/molecules/UserTab/index.tsx
@@ -31,11 +31,11 @@ const UserTab = ({ user, usage }: UserTabProps) => {
     }
     const nameStyle = {
         TeamMembers: 'text-md',
-        UserList: 'text-2xl font-semibold',
+        UserList: 'text-xl font-semibold truncate',
     }
     const roleStyle = {
         TeamMembers: 'hidden text-sm lg:flex',
-        UserList: 'text-xl text-primary-gray ',
+        UserList: 'text-xl text-primary-gray truncate',
     }
     if (!isObjectEmpty(user)) {
         return (
@@ -51,7 +51,7 @@ const UserTab = ({ user, usage }: UserTabProps) => {
                     src={user.avatar}
                     maxInitials={1}
                     textSizeRatio={2}
-                    className={`rounded-full bg-gray-800 text-sm active:ring-2 active:ring-red-500 md:mr-0`}
+                    className={`flex-0 aspect-square bg-gray-800 text-sm active:ring-2 active:ring-red-500 md:mr-0`}
                 />
                 <div className="text-overflow-ellipsis ml-2 flex flex-col overflow-hidden align-middle">
                     <div className={nameStyle[usage]}>

--- a/frontend/helpers/graphql/queries/get_roles.ts
+++ b/frontend/helpers/graphql/queries/get_roles.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client'
+
+const GET_ROLES = gql`
+    query Roles {
+        roles {
+            id
+            name
+        }
+    }
+`
+
+export default GET_ROLES

--- a/frontend/helpers/graphql/queries/get_users.ts
+++ b/frontend/helpers/graphql/queries/get_users.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client'
+
+const GET_USERS = gql`
+    query Users($first: Int!, $page: Int!, $filter: userFilter, $sort: userSort) {
+        users(first: $first, page: $page, filter: $filter, sort: $sort) {
+            paginatorInfo {
+                perPage
+                currentPage
+                lastPage
+                hasMorePages
+                total
+            }
+            data {
+                id
+                first_name
+                last_name
+                avatar
+                reputation
+                slug
+                role {
+                    name
+                }
+            }
+        }
+    }
+`
+
+export default GET_USERS

--- a/frontend/pages/questions/index.tsx
+++ b/frontend/pages/questions/index.tsx
@@ -13,6 +13,7 @@ import { HiSearch } from 'react-icons/hi'
 import DropdownFilters from '@/components/molecules/DropdownFilters'
 
 export interface PaginatorInfo {
+    perPage: number
     currentPage: number
     lastPage: number
     total: number


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-51

## Commands
none

## Pre-conditions
You must have a role assigned to your user.

If none, run
```
cd backend
php artisan migrate
```
Then manually delete your account and login again.

## Expected Output
Users page will display a list of paginated users.

You can search a user by their name, filter by their roles and sort by the reputation scores.

## Notes
Entering an input on the search input will clear all selected filters.
Entering with an empty input will return all users.

## Screenshots
_All users_
<img width="951" alt="image" src="https://user-images.githubusercontent.com/116238730/220512230-aa9f55df-d0ff-41b5-889e-6d5cd0e0ac4f.png">

_All users page 2_
<img width="959" alt="image" src="https://user-images.githubusercontent.com/116238730/220512583-6587a166-39f9-43c0-9417-fe776547de73.png">

_Search_
<img width="954" alt="image" src="https://user-images.githubusercontent.com/116238730/220512645-8169db44-0bf2-421e-824f-57a74398330e.png">

_Filters_
<img width="957" alt="image" src="https://user-images.githubusercontent.com/116238730/220512769-e6e8787a-d393-489b-b1d0-979256cb0999.png">

_Search Results + Filters_
<img width="958" alt="image" src="https://user-images.githubusercontent.com/116238730/220512931-0e436bd8-dcb4-45bd-b5bf-546a3753dba0.png">

