### PR TITLE
[OVERFLOW-266] Update question detail API to add sorting of votes and created_at

### DIFF
--- a/backend/app/GraphQL/Queries/Question.php
+++ b/backend/app/GraphQL/Queries/Question.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Queries;
 
 use App\Models\Question as ModelsQuestion;
+use Illuminate\Support\Facades\DB;
 
 final class Question
 {
@@ -12,12 +13,28 @@ final class Question
      */
     public function __invoke($_, array $args)
     {
-        $question = ModelsQuestion::where('slug', $args['slug'])->first();
+        $questionQuery = ModelsQuestion::query();
+
+        if (isset($args['answerSort'])) {
+            $questionQuery->with(['answers' => function ($query) use ($args) {
+                foreach ($args['answerSort'] as $sort) {
+                    if ($sort['column'] == 'votes_sum_value') {
+                        $query->withSum(['votes' => function ($query) {
+                            $query->select(DB::raw('COALESCE(SUM(value), 0)'));
+                        }], 'value');
+                    }
+
+                    $query->orderBy($sort['column'], $sort['order']);
+                }
+            }]);
+        }
+
+        $question = $questionQuery->where('slug', $args['slug'])->first();
 
         if ($args['shouldAddViewCount']) {
             $question->update(['views_count' => $question->views_count + 1]);
         }
 
-        return $question->fresh();
+        return $question;
     }
 }

--- a/backend/app/Models/Question.php
+++ b/backend/app/Models/Question.php
@@ -20,6 +20,8 @@ class Question extends Model
 
     protected $guarded = [];
 
+    protected $with = ['answers'];
+
     protected $appends = ['vote_count', 'humanized_created_at', 'is_from_user', 'user_vote', 'is_answered'];
 
     protected static function boot()

--- a/backend/graphql/question/query.graphql
+++ b/backend/graphql/question/query.graphql
@@ -4,9 +4,27 @@ input filter {
     tag: ID
 }
 
+enum ORDERBY {
+    ASC
+    DESC
+}
+
+enum COLUMNS {
+    CREATED_AT @enum(value: "created_at")
+    VOTES @enum(value: "votes_sum_value")
+}
+
+input answerSort {
+    column: COLUMNS
+    order: ORDERBY = ASC
+}
+
 extend type Query {
-    question(slug: String! @eq, shouldAddViewCount: Boolean = true): Question
-        @guard(with: ["api"])
+    question(
+        slug: String! @eq
+        shouldAddViewCount: Boolean = true
+        answerSort: [answerSort]
+    ): Question @guard(with: ["api"])
     questions(
         orderBy: _ @orderBy(columns: ["created_at"])
         filter: filter @spread

--- a/backend/graphql/question/type.graphql
+++ b/backend/graphql/question/type.graphql
@@ -15,7 +15,7 @@ type Question {
     is_bookmarked: Boolean
     is_from_user: Boolean
     user: User! @belongsTo
-    answers: [Answer!]! @hasMany
+    answers: [Answer!]!
     comments: [Comment]! @morphMany
     votes: [Vote]! @morphMany
     team: Team @belongsTo


### PR DESCRIPTION

## Backlog Link
[SUN_OVERFLOW-266](https://framgiaph.backlog.com/view/SUN_OVERFLOW-266)
## Commands
`cd backend`
`composer dump-autoload`
## Pre-conditions
None
## Expected Output
You can now sort answers of a Question by votes and created at
## Notes
None
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/220585595-c2d60cb7-cbba-4ff1-9d3f-c4950f1d3474.png)
![image](https://user-images.githubusercontent.com/116168014/220585648-e166eba8-6e05-48da-b3e6-36db806adbab.png)
![image](https://user-images.githubusercontent.com/116168014/220585713-e254f98c-bcf5-4f8b-b648-de9cfac97f3c.png)
![image](https://user-images.githubusercontent.com/116168014/220585746-5a9e8d42-2ebc-4f1a-a9d3-be9291c00b3e.png)
