### PR TITLE
[Overflow-267] [FE] Integrate sort answers in question detail page

### DIFF
--- a/frontend/helpers/graphql/queries/get_question.ts
+++ b/frontend/helpers/graphql/queries/get_question.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 const GET_QUESTION = gql`
-    query getQuestion($slug: String!, $shouldAddViewCount: Boolean) {
-        question(slug: $slug, shouldAddViewCount: $shouldAddViewCount) {
+    query getQuestion($slug: String!, $shouldAddViewCount: Boolean, $answerSort: [answerSort]) {
+        question(slug: $slug, shouldAddViewCount: $shouldAddViewCount, answerSort: $answerSort) {
             id
             title
             content

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -77,6 +77,12 @@ export type AnswerEditType = {
     content: string | null
 }
 
+type RefetchType = {
+    slug?: string
+    shouldAddViewCount: boolean
+    answerSort?: { column: string; order: string }[]
+}
+
 const QuestionDetailPage = () => {
     const router = useRouter()
     const [comment, setComment] = useState(false)
@@ -86,10 +92,11 @@ const QuestionDetailPage = () => {
 
     const query = router.query
 
-    const { data, loading, error, refetch } = useQuery(GET_QUESTION, {
+    const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTION, {
         variables: {
             slug: String(query.slug),
             shouldAddViewCount: true,
+            answerSort: [{ column: 'VOTES', order: 'DESC' }],
         },
     })
 
@@ -103,23 +110,55 @@ const QuestionDetailPage = () => {
         refetch({ shouldAddViewCount: false })
     }
 
-    const answerFilters: FilterType[] = [
-        {
-            id: 1,
-            name: 'Highest Score',
-            onClick: () => {
-                console.log('Highest Score!')
-                setSelectedAnswerFilter('Highest Score')
+    const answerFilters: FilterType[][] = [
+        [
+            {
+                id: 1,
+                name: 'Highest Score',
+                onClick: () => {
+                    refetch({
+                        shouldAddViewCount: false,
+                        answerSort: [{ column: 'VOTES', order: 'DESC' }],
+                    })
+                    setSelectedAnswerFilter('Highest Score')
+                },
             },
-        },
-        {
-            id: 2,
-            name: 'Date Posted',
-            onClick: () => {
-                console.log('Date Posted!')
-                setSelectedAnswerFilter('Date Posted')
+            {
+                id: 2,
+                name: 'Lowest Score',
+                onClick: () => {
+                    refetch({
+                        shouldAddViewCount: false,
+                        answerSort: [{ column: 'VOTES', order: 'ASC' }],
+                    })
+                    setSelectedAnswerFilter('Lowest Score')
+                },
             },
-        },
+        ],
+        [
+            {
+                id: 3,
+                name: 'Most Recent',
+                onClick: () => {
+                    refetch({
+                        shouldAddViewCount: false,
+                        answerSort: [{ column: 'CREATED_AT', order: 'DESC' }],
+                    })
+                    setSelectedAnswerFilter('Most Recent')
+                },
+            },
+            {
+                id: 2,
+                name: 'Least Recent',
+                onClick: () => {
+                    refetch({
+                        shouldAddViewCount: false,
+                        answerSort: [{ column: 'CREATED_AT', order: 'ASC' }],
+                    })
+                    setSelectedAnswerFilter('Least Recent')
+                },
+            },
+        ],
     ]
 
     return (
@@ -184,6 +223,7 @@ const QuestionDetailPage = () => {
                             <span className="w-[9rem] pr-2 text-end text-sm">Sorted by:</span>
                             <div className="w-44">
                                 <SortDropdown
+                                    grouped={true}
                                     filters={answerFilters}
                                     selectedFilter={selectedAnswerFilter}
                                 />
@@ -198,7 +238,7 @@ const QuestionDetailPage = () => {
                                 onEdit={setAnswer}
                                 question_id={question.id}
                                 content={answer.content}
-                                created_at={answer.created_at}
+                                created_at={answer.humanized_created_at}
                                 vote_count={answer.vote_count}
                                 is_bookmarked={answer.is_bookmarked}
                                 is_correct={answer.is_correct}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-267

## Commands
none

## Pre-conditions
none

## Expected Output
Answers can be sorted according to the filters in the Question Detail Page

## Notes

## Screenshots
_Sort by Highest Score_
<img width="463" alt="image" src="https://user-images.githubusercontent.com/116238730/220826361-e9d8ec46-18ba-45a6-97f6-9288cd4168e9.png">

_Sort by Lowest Score_
<img width="468" alt="image" src="https://user-images.githubusercontent.com/116238730/220826411-55d340d3-8efd-4d84-bc7b-391357fcae8e.png">

_Sort by Most Recent_
<img width="469" alt="image" src="https://user-images.githubusercontent.com/116238730/220826474-e197f9a4-eee9-4b7e-8a30-c04692535c4a.png">

_Sort by Least Recent_
<img width="471" alt="image" src="https://user-images.githubusercontent.com/116238730/220826510-00365803-7a14-4aea-89f2-173a9c137de5.png">

