### PR TITLE
[OVERFLOW-33]  Implement API to tag component

### DIFF
--- a/frontend/components/molecules/Pill/index.tsx
+++ b/frontend/components/molecules/Pill/index.tsx
@@ -6,11 +6,18 @@ import { usePopper } from 'react-popper'
 import { Float } from '@headlessui-float/react'
 
 type PillProps = {
-    name: string
-    is_tag: boolean
+    tag: {
+        id: number
+        slug: string
+        name: string
+        description: string
+        is_watched_by_user: boolean
+        count_tagged_questions: number
+        count_watching_users: number
+    }
 }
 
-const Pill = ({ name, is_tag }: PillProps): JSX.Element => {
+const Pill = ({ tag }: PillProps): JSX.Element => {
     const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>()
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>()
     const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>()
@@ -26,8 +33,8 @@ const Pill = ({ name, is_tag }: PillProps): JSX.Element => {
                         className="flex min-w-fit flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal !outline-none"
                         ref={setReferenceElement}
                     >
-                        {is_tag ? <Icons name="pill_eye" /> : ''}
-                        <span>{name}</span>
+                        {tag.is_watched_by_user ? <Icons name="pill_eye" /> : ''}
+                        <span>{tag.name}</span>
                     </div>
                 </Popover.Button>
                 <Popover.Panel
@@ -39,7 +46,7 @@ const Pill = ({ name, is_tag }: PillProps): JSX.Element => {
                     <div ref={setArrowElement} style={styles.arrow}>
                         <Float.Arrow className="relative ml-3 h-6 w-6 rotate-45 bg-zinc-200" />
                     </div>
-                    <Tooltips />
+                    <Tooltips tag={tag} />
                 </Popover.Panel>
             </Float>
         </Popover>

--- a/frontend/components/molecules/Tags/index.tsx
+++ b/frontend/components/molecules/Tags/index.tsx
@@ -1,14 +1,22 @@
 import Pill from '../Pill'
 
 type TagsProps = {
-    values?: { id: number; name: string; is_watched_by_user: boolean }[]
+    values: {
+        id: number
+        slug: string
+        name: string
+        description: string
+        is_watched_by_user: boolean
+        count_tagged_questions: number
+        count_watching_users: number
+    }[]
 }
 
 const Tags = ({ values }: TagsProps): JSX.Element => {
     return (
         <div className="flex w-full justify-start gap-2">
             {values?.map((value) => {
-                return <Pill key={value.id} name={value.name} is_tag={value.is_watched_by_user} />
+                return <Pill key={value.id} tag={value} />
             })}
         </div>
     )

--- a/frontend/components/molecules/Tooltip/index.tsx
+++ b/frontend/components/molecules/Tooltip/index.tsx
@@ -1,25 +1,84 @@
 import Button from '@/components/atoms/Button'
+import { ADD_WATCHED_TAG, REMOVE_WATCHED_TAG } from '@/helpers/graphql/mutations/sidebar'
+import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
+import { LOAD_SIDEBAR_1 } from '@/helpers/graphql/queries/sidebar'
+import { errorNotify, successNotify } from '@/helpers/toast'
+import { useMutation } from '@apollo/client'
+import { useRouter } from 'next/router'
 import React from 'react'
 
-const Tooltips = (): JSX.Element => {
+type TagType = {
+    tag: {
+        id: number
+        slug: string
+        name: string
+        description: string
+        is_watched_by_user: boolean
+        count_tagged_questions: number
+        count_watching_users: number
+    }
+}
+
+const Tooltips = ({ tag }: TagType): JSX.Element => {
+    const router = useRouter()
+
+    const [addWatchedTagAPI] = useMutation(ADD_WATCHED_TAG, {
+        refetchQueries: [
+            { query: LOAD_SIDEBAR_1 },
+            'LoadSidebar1',
+            { query: GET_QUESTIONS },
+            'Questions',
+        ],
+        onCompleted: (data) => {
+            if (data.addWatchedTag == 'Successfully added the tag') {
+                successNotify(data.addWatchedTag)
+            } else {
+                errorNotify(data.addWatchedTag)
+            }
+        },
+    })
+    const [removeWatchedTagAPI] = useMutation(REMOVE_WATCHED_TAG, {
+        refetchQueries: [
+            { query: LOAD_SIDEBAR_1 },
+            'LoadSidebar1',
+            { query: GET_QUESTIONS },
+            'Questions',
+        ],
+
+        onCompleted: (data) => {
+            if (data.removeWatchedTag == 'Successfully removed tag from WatchList') {
+                successNotify(data.removeWatchedTag)
+            } else {
+                errorNotify(data.removeWatchedTag)
+            }
+        },
+    })
+
+    const toggleTagWatch = () => {
+        if (tag.is_watched_by_user) removeWatchedTagAPI({ variables: { tagId: tag.id } })
+        else addWatchedTagAPI({ variables: { tagId: tag.id } })
+    }
+
     return (
         <div className="p-5">
             <div className="flex items-center">
-                <p className="mr-20 text-red-700">100k Watchers</p>
-                <p className="mr-2">100K Questions</p>
+                <p className="mr-20 text-red-700">{tag.count_watching_users} Watchers</p>
+                <p className="mr-2">{tag.count_tagged_questions} Questions</p>
             </div>
-            <div className="">
+            <div className=" cursor-pointer py-2">
                 <p>
-                    Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsa qui possimus,
-                    alias veritatis dicta atque dolores.
-                    <a className="ml-2 underline" href="">
+                    {tag.description}
+                    <a
+                        className="ml-2 underline "
+                        onClick={() => router.push(`/questions/tagged/${tag.slug}`)}
+                    >
                         View Tag
                     </a>
                 </p>
             </div>
-            <div className="float-right ml-2 p-2">
-                <Button usage="popover" type="submit" onClick={undefined}>
-                    Watch Tag
+            <div className="float-right ml-2 mb-2 p-2">
+                <Button usage="popover" type="submit" onClick={() => toggleTagWatch()}>
+                    {`${tag.is_watched_by_user ? 'Unw' : 'W'}atch Tag`}
                 </Button>
             </div>
         </div>

--- a/frontend/components/molecules/Tooltip/index.tsx
+++ b/frontend/components/molecules/Tooltip/index.tsx
@@ -5,7 +5,6 @@ import { LOAD_SIDEBAR_1 } from '@/helpers/graphql/queries/sidebar'
 import { errorNotify, successNotify } from '@/helpers/toast'
 import { useMutation } from '@apollo/client'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import React from 'react'
 
 type TagType = {
@@ -21,8 +20,6 @@ type TagType = {
 }
 
 const Tooltips = ({ tag }: TagType): JSX.Element => {
-    const router = useRouter()
-
     const [addWatchedTagAPI] = useMutation(ADD_WATCHED_TAG, {
         refetchQueries: [
             { query: LOAD_SIDEBAR_1 },

--- a/frontend/components/molecules/Tooltip/index.tsx
+++ b/frontend/components/molecules/Tooltip/index.tsx
@@ -4,6 +4,7 @@ import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
 import { LOAD_SIDEBAR_1 } from '@/helpers/graphql/queries/sidebar'
 import { errorNotify, successNotify } from '@/helpers/toast'
 import { useMutation } from '@apollo/client'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React from 'react'
 
@@ -68,12 +69,9 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
             <div className=" cursor-pointer py-2">
                 <p>
                     {tag.description}
-                    <a
-                        className="ml-2 underline "
-                        onClick={() => router.push(`/questions/tagged/${tag.slug}`)}
-                    >
+                    <Link href={`/questions/tagged/${tag.slug}`} className="ml-2 underline ">
                         View Tag
-                    </a>
+                    </Link>
                 </p>
             </div>
             <div className="float-right ml-2 mb-2 p-2">

--- a/frontend/components/molecules/WatchedTags/index.tsx
+++ b/frontend/components/molecules/WatchedTags/index.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery } from '@apollo/client'
 import { GET_TAG_SUGGESTIONS, LOAD_SIDEBAR_1 } from '@/helpers/graphql/queries/sidebar'
 import { ADD_WATCHED_TAG, REMOVE_WATCHED_TAG } from '@/helpers/graphql/mutations/sidebar'
 import { errorNotify, successNotify } from '@/helpers/toast'
+import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
 
 type TTag = {
     id: number
@@ -31,7 +32,12 @@ const WatchedTags = ({ data, loading = true }: WatchedTagsProps) => {
         variables: { queryString: `%${queryText}%` },
     })
     const [addWatchedTagAPI] = useMutation(ADD_WATCHED_TAG, {
-        refetchQueries: [{ query: LOAD_SIDEBAR_1 }, 'LoadSidebar1'],
+        refetchQueries: [
+            { query: LOAD_SIDEBAR_1 },
+            'LoadSidebar1',
+            { query: GET_QUESTIONS },
+            'Questions',
+        ],
         onCompleted: (data) => {
             if (data.addWatchedTag == 'Successfully added the tag') {
                 successNotify(data.addWatchedTag)
@@ -41,7 +47,12 @@ const WatchedTags = ({ data, loading = true }: WatchedTagsProps) => {
         },
     })
     const [removeWatchedTagAPI] = useMutation(REMOVE_WATCHED_TAG, {
-        refetchQueries: [{ query: LOAD_SIDEBAR_1 }, 'LoadSidebar1'],
+        refetchQueries: [
+            { query: LOAD_SIDEBAR_1 },
+            'LoadSidebar1',
+            { query: GET_QUESTIONS },
+            'Questions',
+        ],
         onCompleted: (data) => {
             if (data.removeWatchedTag == 'Successfully removed tag from WatchList') {
                 successNotify(data.removeWatchedTag)

--- a/frontend/helpers/graphql/queries/get_questions.ts
+++ b/frontend/helpers/graphql/queries/get_questions.ts
@@ -30,6 +30,10 @@ const GET_QUESTIONS = gql`
                     id
                     name
                     is_watched_by_user
+                    slug
+                    description
+                    count_tagged_questions
+                    count_watching_users
                 }
                 user {
                     id

--- a/frontend/pages/questions/tagged/[slug].tsx
+++ b/frontend/pages/questions/tagged/[slug].tsx
@@ -22,10 +22,17 @@ const TagsPage = () => {
         },
     })
 
-    const { slug } = router.query
     useEffect(() => {
+        const { slug } = router.query
+
+        refetch({
+            first: 10,
+            page: 1,
+            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            filter: { answered: true, tag: selectedTag },
+        })
         setSelectedTag(slug as string)
-    }, [slug])
+    }, [router, selectedTag, refetch])
 
     if (loading) return loadingScreenShow()
     if (error) return errorNotify(`Error! ${error}`)

--- a/frontend/pages/tags/index.tsx
+++ b/frontend/pages/tags/index.tsx
@@ -156,7 +156,7 @@ const TagsListPage = () => {
                                 <Card
                                     header={
                                         <div className="pt-1">
-                                            <Pill name={tag.slug} is_tag={tag.is_watched_by_user} />
+                                            <Pill tag={tag} />
                                         </div>
                                     }
                                     footer={`${tag.count_tagged_questions} ${


### PR DESCRIPTION
## Backlog Link
[SUN_OVERFLOW-33](https://framgiaph.backlog.com/view/SUN_OVERFLOW-33)
## Commands
NONE
## Pre-conditions
none
## Expected Output
User can now click the the Tag pill and do do : 
- redirect to tag detail page
- watch and unwatch a tag
- when watching or unwatching queries from other componenets such as right sidebar and question page must refetch to have updated record of data
## Notes
none
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/220837543-9c4abc41-b5e5-4600-8119-aa148127a12f.png)
![image](https://user-images.githubusercontent.com/116168014/220837559-922cf18e-7c9c-4695-9c24-7429ef5d83ed.png)
![image](https://user-images.githubusercontent.com/116168014/220837579-a33df992-da3f-4ee6-ad71-fe7e6f0e7650.png)

