### PR TITLE
[Overflow-270] Create Seeder for Teams

### DIFF
--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -11,7 +11,6 @@ class Team extends Model
 {
     use HasFactory, SoftDeletes;
     protected static function boot()
-
     {
         parent::boot();
 

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -5,10 +5,38 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Team extends Model
 {
     use HasFactory, SoftDeletes;
+    protected static function boot()
+
+    {
+        parent::boot();
+
+        static::creating(function ($team) {
+            $slug = Str::slug($team->name);
+
+            $duplicateCount = Team::where('name', $team->name)->count();
+
+            $team->slug = $duplicateCount === 0 ? $slug : "$slug-duplicate-".time();
+        });
+
+        static::updating(function ($team) {
+            $slug = Str::slug($team->name);
+
+            $teamFirst = Team::where('name', $team->name)->first();
+            $duplicateCount = Team::where('name', $team->name)->count();
+
+            if ($teamFirst?->id !== $team->id) {
+                $team->slug = $duplicateCount === 0 ? $slug : "$slug-duplicate-".time();
+            }
+        });
+    }
+
+
+
 
     public function teamLeader()
     {

--- a/backend/database/factories/MemberFactory.php
+++ b/backend/database/factories/MemberFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ */
+class MemberFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+
+        $userId = DB::table('users')->pluck('id')->random();
+        $teamId = DB::table('teams')->pluck('id')->random();
+        return [
+                    'user_id' => $userId,
+                    'team_role_id' => random_int(2, 3),
+                    'team_id' => $teamId,
+        ];
+    }
+}

--- a/backend/database/factories/TeamFactory.php
+++ b/backend/database/factories/TeamFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ */
+class TeamFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+
+        $userId = DB::table('users')->pluck('id')->random();
+        return [
+            'name'=> fake()->company(),
+            'description' => fake()->bs(),
+            'dashboard_content'=> '<p>'.fake()->paragraph($nbSentences = 1, $variableNbSentences = true).'</p>',
+            'user_id'=> $userId,
+        ];
+    }
+}

--- a/backend/database/migrations/2023_03_01_114957_add_slug_to_teams.php
+++ b/backend/database/migrations/2023_03_01_114957_add_slug_to_teams.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->string('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/backend/database/seeders/MemberSeeder.php
+++ b/backend/database/seeders/MemberSeeder.php
@@ -14,37 +14,6 @@ class MemberSeeder extends Seeder
      */
     public function run()
     {
-        Member::upsert([
-            [
-                'id' => 1,
-                'user_id' => 6,
-                'team_role_id' => 1,
-                'team_id' => 1,
-            ],
-            [
-                'id' => 2,
-                'user_id' => 7,
-                'team_role_id' => 2,
-                'team_id' => 1,
-            ],
-            [
-                'id' => 3,
-                'user_id' => 8,
-                'team_role_id' => 3,
-                'team_id' => 1,
-            ],
-            [
-                'id' => 4,
-                'user_id' => 9,
-                'team_role_id' => 1,
-                'team_id' => 2,
-            ],
-            [
-                'id' => 5,
-                'user_id' => 10,
-                'team_role_id' => 1,
-                'team_id' => 3,
-            ],
-        ], ['id'], ['user_id', 'team_role_id', 'team_id']);
+        Member::factory(50)->create();
     }
 }

--- a/backend/database/seeders/TeamSeeder.php
+++ b/backend/database/seeders/TeamSeeder.php
@@ -12,44 +12,9 @@ class TeamSeeder extends Seeder
      *
      * @return void
      */
+
     public function run()
     {
-        Team::upsert([
-            [
-                'id' => 1,
-                'name' => 'Team 1',
-                'description' => 'This is Team 1',
-                'dashboard_content' => 'Team 1 content',
-                'user_id' => 1,
-            ],
-            [
-                'id' => 2,
-                'name' => 'Team 2',
-                'description' => 'This is Team 2',
-                'dashboard_content' => 'Team 2 content',
-                'user_id' => 2,
-            ],
-            [
-                'id' => 3,
-                'name' => 'Team 3',
-                'description' => 'This is Team 3',
-                'dashboard_content' => 'Team 3 content',
-                'user_id' => 3,
-            ],
-            [
-                'id' => 4,
-                'name' => 'Team 4',
-                'description' => 'This is Team 4',
-                'dashboard_content' => 'Team 4 content',
-                'user_id' => 4,
-            ],
-            [
-                'id' => 5,
-                'name' => 'Team 5',
-                'description' => 'This is Team 5',
-                'dashboard_content' => 'Team 5 content',
-                'user_id' => 5,
-            ],
-        ], ['id'], ['name', 'description', 'dashboard_content', 'user_id']);
+        Team::factory(20)->create();
     }
 }

--- a/backend/database/seeders/UserRelationSeeder.php
+++ b/backend/database/seeders/UserRelationSeeder.php
@@ -14,6 +14,6 @@ class UserRelationSeeder extends Seeder
      */
     public function run()
     {
-        UserRelation::factory(5)->create();
+        UserRelation::factory(10)->create();
     }
 }

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -14,6 +14,6 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
-        User::factory(20)->create();
+        User::factory(30)->create();
     }
 }

--- a/backend/graphql/team/type.graphql
+++ b/backend/graphql/team/type.graphql
@@ -7,6 +7,7 @@ type Team {
     updated_at: String
     teamLeader: User! @belongsTo
     members: [Member!]! @hasMany
+    slug: String!
 }
 
 type Member {


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-270

## Commands
in backend:
`php artisan migrate:fresh --seed`

## Pre-conditions

## Expected Output
Added new Factories for Teams and Members

Expanded the seeded values for the following tables:
* Users
* Teams
* Members
* Relations

 
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/222042001-9e32b2db-25cc-42e4-aea0-16013f25f804.png)
![image](https://user-images.githubusercontent.com/114897466/222042275-8cbc97b6-3a09-4cf1-b2aa-c6fc8bcde5d1.png)
