### PR TITLE
[Overflow-64] Teams List Page Markup

### DIFF
--- a/frontend/components/molecules/TeamMembersSidebar/index.tsx
+++ b/frontend/components/molecules/TeamMembersSidebar/index.tsx
@@ -38,7 +38,7 @@ const TeamMemberSidebar = ({ data, loading }: MembersSidebarProps) => {
     }
     useEffect(() => {
         if (!loading) {
-            setMembers(extractMembers())
+            setMembers([])
         }
     }, [data])
     return (

--- a/frontend/components/organisms/Sidebar/RightSideBar.tsx
+++ b/frontend/components/organisms/Sidebar/RightSideBar.tsx
@@ -8,7 +8,7 @@ type TRightSidebarProps = {
     usage: null | 'teams' | 'users' | string
 }
 const RightSideBar = ({ usage }: TRightSidebarProps) => {
-    if (usage === 'teams') {
+    if (usage === 'team') {
         return <Type2 />
     }
     if (usage === 'users') {

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -48,7 +48,14 @@ const Layout = ({ children }: LayoutProps) => {
                         !hideRightSidebarInPages.includes(router.pathname) && (
                             <div className="relative mr-14 w-1/5 pt-20">
                                 <div className="fixed w-1/5">
-                                    <RightSideBar usage={router.pathname.split('/')[1]} />
+                                    <RightSideBar
+                                        usage={
+                                            router.pathname.split('/')[1] === 'teams' &&
+                                            router.pathname.split('/').length > 2
+                                                ? 'team'
+                                                : router.pathname.split('/')[1]
+                                        }
+                                    />
                                 </div>
                             </div>
                         )}

--- a/frontend/pages/team/[teamId].tsx
+++ b/frontend/pages/team/[teamId].tsx
@@ -1,9 +1,0 @@
-import { RightSideBar } from '@/components/organisms/Sidebar'
-const team = () => {
-    return (
-        <div className="flex flex-row-reverse">
-            <RightSideBar usage="members" />
-        </div>
-    )
-}
-export default team

--- a/frontend/pages/teams/[teamId].tsx
+++ b/frontend/pages/teams/[teamId].tsx
@@ -1,4 +1,4 @@
-const teams = () => {
+const team = () => {
     return <div className="flex flex-row-reverse"></div>
 }
-export default teams
+export default team

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -1,0 +1,116 @@
+import PageHeader from '@/components/atoms/PageHeader'
+import SearchInput from '@/components/molecules/SearchInput'
+import Paginate from '@/components/organisms/Paginate'
+import Card from '@/components/templates/Card'
+import Link from 'next/link'
+import { useState } from 'react'
+import { PaginatorInfo } from '../questions'
+
+type TeamType = {
+    id: number
+    name: string
+    description: string
+    slug: string
+    members_count: number
+}
+
+const TeamsListPage = () => {
+    const [searchKey, setSearchKey] = useState('')
+
+    const teamsList: TeamType[] = [
+        {
+            id: 1,
+            name: 'Sun Overflow',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            slug: 'sun-overflow',
+            members_count: 12,
+        },
+        {
+            id: 2,
+            name: 'HRIS',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            slug: 'hris',
+            members_count: 13,
+        },
+        {
+            id: 3,
+            name: 'Zeon',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            slug: 'zeon',
+            members_count: 14,
+        },
+        {
+            id: 4,
+            name: 'Metajob',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            slug: 'metajob',
+            members_count: 15,
+        },
+    ]
+
+    const pageInfo: PaginatorInfo = {
+        perPage: 6,
+        currentPage: 1,
+        lastPage: 2,
+        total: 4,
+        hasMorePages: true,
+    }
+
+    const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+
+        const target = e.target as typeof e.target & {
+            search: { value: string }
+        }
+
+        // TODO: set API call for search teams
+        console.log(target.search.value)
+    }
+
+    const onChange = (value: string) => {
+        setSearchKey(value)
+    }
+
+    const onPageChange = () => {
+        // TODO: set API call for refetch on paginate
+        console.log('Next page')
+    }
+    return (
+        <div className="flex h-full w-full flex-col gap-3 divide-y-2 divide-primary-gray px-10 pt-8 pb-5">
+            <PageHeader>Teams</PageHeader>
+            <div className="flex h-full w-full flex-col gap-2 px-5 pt-3">
+                <div className="flex w-full flex-row items-center justify-between">
+                    <div className="mt-2 flex flex-row items-center justify-between px-2">
+                        <form onSubmit={handleSearchSubmit}>
+                            <SearchInput
+                                placeholder="Search team"
+                                value={searchKey}
+                                onChange={onChange}
+                            />
+                        </form>
+                    </div>
+                </div>
+                <div className="mt-4 flex h-full w-full flex-col justify-between gap-5">
+                    <div className="grid w-full grid-cols-2 gap-5 px-3">
+                        {teamsList.map((team) => (
+                            <Link key={team.id} href={`teams/${team.slug}`}>
+                                <Card header={team.name} footer={`${team.members_count} members`}>
+                                    {team.description}
+                                </Card>
+                            </Link>
+                        ))}
+                    </div>
+                    {pageInfo.lastPage > 1 && (
+                        <Paginate {...pageInfo} onPageChange={onPageChange} />
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default TeamsListPage

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -95,7 +95,7 @@ const TeamsListPage = () => {
                     </div>
                 </div>
                 <div className="mt-4 flex h-full w-full flex-col justify-between gap-5">
-                    <div className="grid w-full grid-cols-2 gap-5 px-3">
+                    <div className="grid w-full grid-cols-2 gap-y-5 gap-x-10 px-3">
                         {teamsList.map((team) => (
                             <Link key={team.id} href={`teams/${team.slug}`}>
                                 <Card header={team.name} footer={`${team.members_count} members`}>


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-64

## Commands
none

## Pre-conditions
none

## Expected Output
Teams are listed in cards with pagination. Clicking on a card will redirect to the team detail page (currently empty). 
Being on the team detail page will also update the sidebar to contain the members list

## Notes

## Screenshots
_Teams List Page_
<img width="667" alt="image" src="https://user-images.githubusercontent.com/116238730/222058026-229e4084-462f-4db0-8db1-833b9a4f04e8.png">

_After clicking on a card_
<img width="670" alt="image" src="https://user-images.githubusercontent.com/116238730/222058089-fcf905bc-5a05-412c-945e-ac7bc7bcb166.png">
