### PR TITLE
[Overflow-142] [FE] Integrate Team Detail Page

### DIFF
--- a/frontend/helpers/graphql/queries/get_team.ts
+++ b/frontend/helpers/graphql/queries/get_team.ts
@@ -1,0 +1,37 @@
+import { gql } from '@apollo/client'
+
+const GET_TEAM = gql`
+    query getTeam($slug: String!) {
+        team(slug: $slug) {
+            id
+            name
+            description
+            dashboard_content
+            teamLeader {
+                id
+                slug
+                first_name
+                last_name
+                reputation
+                role {
+                    name
+                }
+            }
+            members {
+                id
+                user {
+                    id
+                    slug
+                    first_name
+                    last_name
+                    reputation
+                }
+                teamRole {
+                    name
+                }
+            }
+        }
+    }
+`
+
+export default GET_TEAM

--- a/frontend/pages/teams/[slug].tsx
+++ b/frontend/pages/teams/[slug].tsx
@@ -1,8 +1,58 @@
 import { parseHTML } from '@/helpers/htmlParsing'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import GET_TEAM from '@/helpers/graphql/queries/get_team'
+import { useRouter } from 'next/router'
+import { useQuery } from '@apollo/client'
+import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
+import { errorNotify } from '@/helpers/toast'
+
+type RoleType = {
+    name: string
+}
+
+type UserType = {
+    id: number
+    slug: string
+    first_name: string
+    last_name: string
+    reputation: number
+    role?: RoleType
+}
+
+type MemberType = {
+    id: number
+    user: UserType
+    teamRole: RoleType
+}
+
+type TeamType = {
+    id: number
+    name: string
+    description: string
+    dashboard_content: string
+    teamLeader: UserType
+    members: MemberType[]
+}
 
 const Team = () => {
+    const router = useRouter()
     const [isActiveTab, setIsActiveTab] = useState('dashboard')
+
+    const { data, loading, error, refetch } = useQuery(GET_TEAM, {
+        variables: {
+            slug: router.query.slug,
+        },
+    })
+
+    const team: TeamType = data?.team
+
+    useEffect(() => {
+        refetch()
+    }, [router, refetch])
+
+    if (loading) return loadingScreenShow()
+    else if (error) return errorNotify(`Error! ${error}`)
+
     const getActiveTabClass = (status: boolean): string => {
         if (status) {
             return '-mb-[1px] hover:text-primary-red px-6 font-semibold border-b-2 border-primary-red bg-red-100'
@@ -12,16 +62,14 @@ const Team = () => {
 
     const onClickTab = (tab: string) => {
         setIsActiveTab(tab)
-        // refetch({ slug: query.slug })
+        refetch({ slug: router.query.slug })
     }
 
-    const renderActiveTab = () => {
+    const renderActiveTab = (content: string) => {
         return isActiveTab == 'dashboard' ? (
             <div className="ql-snow mx-5 my-4">
                 <div className="ql-editor w-full">
-                    {parseHTML(
-                        '<h1> This is a test content to <strong>SHOW IN MARKUP<strong></h1>'
-                    )}
+                    {content ? parseHTML(content) : `No content to show.`}
                 </div>
             </div>
         ) : null
@@ -29,7 +77,7 @@ const Team = () => {
 
     return (
         <div className="mx-10 mt-10 flex h-full w-full flex-col gap-4">
-            <div className="text-2xl font-bold">SunOverFlow Team</div>
+            <div className="text-2xl font-bold">{team?.name}</div>
             <div className="mt-2 flex h-3/5 flex-col">
                 <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
                     <div
@@ -49,7 +97,7 @@ const Team = () => {
                         Questions
                     </div>
                 </div>
-                {renderActiveTab()}
+                {renderActiveTab(team?.dashboard_content)}
             </div>
         </div>
     )


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-142

## Commands
none

## Pre-conditions
none

## Expected Output
Team name and dashboard content are displayed in the team detail page.

## Notes
- Does not yet include questions tab and members sidebar (different tasks)

## Screenshots
<img width="945" alt="image" src="https://user-images.githubusercontent.com/116238730/222348377-30fefedd-d771-4c60-86af-a2b2a3d66622.png">
