### PR TITLE
[Overflow-69] Update add question API to include view settings

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateQuestion.php
+++ b/backend/app/GraphQL/Mutations/CreateQuestion.php
@@ -18,7 +18,7 @@ final class CreateQuestion
 
         $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
 
-        if($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+        if ($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
             throw new CustomException('400', 'Public is required when no team is selected');
         }
 

--- a/backend/app/GraphQL/Mutations/CreateQuestion.php
+++ b/backend/app/GraphQL/Mutations/CreateQuestion.php
@@ -2,6 +2,7 @@
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\CustomException;
 use App\Models\Question;
 use Illuminate\Support\Arr;
 
@@ -14,6 +15,12 @@ final class CreateQuestion
     public function __invoke($_, array $args)
     {
         $questionData = Arr::except($args, ['tags']);
+
+        $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
+
+        if($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+            throw new CustomException('400', 'Public is required when no team is selected');
+        }
 
         $questionCreate = auth()->user()->questions()->create($questionData);
 

--- a/backend/app/GraphQL/Mutations/CreateQuestion.php
+++ b/backend/app/GraphQL/Mutations/CreateQuestion.php
@@ -16,9 +16,9 @@ final class CreateQuestion
     {
         $questionData = Arr::except($args, ['tags']);
 
-        $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
+        $hasNoTeam = !isset($args['team_id']) || !$args['team_id'];
 
-        if ($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+        if ($hasNoTeam && (isset($args['is_public']) && !$args['is_public'])) {
             throw new CustomException('400', 'Public is required when no team is selected');
         }
 

--- a/backend/app/GraphQL/Mutations/UpdateQuestion.php
+++ b/backend/app/GraphQL/Mutations/UpdateQuestion.php
@@ -2,6 +2,7 @@
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\CustomException;
 use Illuminate\Support\Arr;
 
 final class UpdateQuestion
@@ -14,6 +15,12 @@ final class UpdateQuestion
     {
         $questionData = Arr::except($args, ['tags', 'id']);
         $question = auth()->user()->questions()->find($args['id']);
+
+        $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
+
+        if($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+            throw new CustomException('400', 'Public is required when no team is selected');
+        }
 
         $question->update($questionData);
 

--- a/backend/app/GraphQL/Mutations/UpdateQuestion.php
+++ b/backend/app/GraphQL/Mutations/UpdateQuestion.php
@@ -18,7 +18,7 @@ final class UpdateQuestion
 
         $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
 
-        if($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+        if ($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
             throw new CustomException('400', 'Public is required when no team is selected');
         }
 

--- a/backend/app/GraphQL/Mutations/UpdateQuestion.php
+++ b/backend/app/GraphQL/Mutations/UpdateQuestion.php
@@ -16,9 +16,9 @@ final class UpdateQuestion
         $questionData = Arr::except($args, ['tags', 'id']);
         $question = auth()->user()->questions()->find($args['id']);
 
-        $hasNoTeam = !isset($args['team_id']) || $args['team_id'] === null;
+        $hasNoTeam = !isset($args['team_id']) || !$args['team_id'];
 
-        if ($hasNoTeam && (isset($args['is_public']) && $args['is_public'] === false)) {
+        if ($hasNoTeam && (isset($args['is_public']) && !$args['is_public'])) {
             throw new CustomException('400', 'Public is required when no team is selected');
         }
 


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-69

## Commands
None

## Pre-conditions
None

## Expected Output
Added view settings in add/edit question api including the validation

## Notes
None

## Screenshots
![image](https://user-images.githubusercontent.com/114911074/222662649-ae0848d7-ad13-4cf7-b43b-22caa2914d1d.png)
![image](https://user-images.githubusercontent.com/114911074/222662710-0c3aca36-e3e0-40d3-a28c-756adebf1a89.png)
