### PR TITLE
[Overflow-282] [MARKUP] Create Modal Form for Managing Team Members

### DIFF
--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -35,6 +35,12 @@ const getButtonClasses = (usage: string): string => {
             return 'absolute top-0 right-0 cursor-pointer'
         case 'back-button':
             return 'text-xl text-primary-gray hover:text-primary-red'
+        case 'toggle-modal':
+            return 'cursor-pointer'
+        case 'modal-cancel':
+            return 'items-center rounded-md border-2 px-4 border-primary-red text-primary-red text-sm hover:bg-light-red py-1'
+        case 'modal-submit':
+            return 'items-center rounded-md bg-primary-red text-white px-4 text-sm hover:bg-secondary-red py-1'
         default:
             return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 border-red-500 focus:ring-red-600 hover:bg-rose-200'
     }

--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -96,7 +96,7 @@ const Icons = ({ name, size = '20', additionalClass }: IconsProps): JSX.Element 
         case 'search_input_icon':
             return <HiSearch size="26" />
         case 'x-plain':
-            return <HiX size={size} />
+            return <HiX size={size} className={`${additionalClass}`} />
         default:
             return <></>
     }

--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -96,7 +96,7 @@ const Icons = ({ name, size = '20', additionalClass }: IconsProps): JSX.Element 
         case 'search_input_icon':
             return <HiSearch size="26" />
         case 'x-plain':
-            return <HiX size={size} className={`${additionalClass}`} />
+            return <HiX size={size} />
         default:
             return <></>
     }

--- a/frontend/components/molecules/Dropdown/index.tsx
+++ b/frontend/components/molecules/Dropdown/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+
+export type OptionType = {
+    id: number
+    name: string
+}
+
+type FormProps = {
+    name: string
+    label: string
+    options: OptionType[]
+}
+
+const Dropdown = ({ name, label, options }: FormProps) => {
+    const [selected, setSelected] = useState(options[0].name)
+
+    return (
+        <div className="w-full">
+            <label>{label}</label>
+            <select
+                id={name}
+                defaultValue={selected}
+                className="w-full rounded-lg border border-secondary-gray px-3 py-2.5 text-sm text-secondary-black focus:border-blue-500 focus:ring-blue-500"
+            >
+                {options.map((option) => {
+                    return (
+                        <option key={option.id} value={option.id}>
+                            {option.name}
+                        </option>
+                    )
+                })}
+            </select>
+        </div>
+    )
+}
+
+export default Dropdown

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -1,5 +1,9 @@
+import Button from '@/components/atoms/Button'
 import Icons from '@/components/atoms/Icons'
 import Link from 'next/link'
+import Dropdown, { OptionType } from '@/components/molecules/Dropdown'
+import Modal from '@/components/templates/Modal'
+import { useState } from 'react'
 
 export type ColumnType = {
     key: string
@@ -16,7 +20,29 @@ type TableProps = {
     dataSource: DataType[]
 }
 
+const roles: OptionType[] = [
+    { id: 1, name: 'FE' },
+    { id: 2, name: 'BE' },
+    { id: 3, name: 'QA' },
+]
+
 const Table = ({ columns, dataSource }: TableProps) => {
+    const [activeModal, setActiveModal] = useState('')
+    const [isOpen, setIsOpen] = useState(false)
+
+    const handleEditSubmit = () => {
+        console.log('member role updated!')
+    }
+
+    const openModal = (modal: string) => {
+        setActiveModal(modal)
+        setIsOpen(true)
+    }
+
+    const closeModal = (modal: string) => {
+        setActiveModal(modal)
+        setIsOpen(false)
+    }
     return (
         <div className="flex flex-col border-black">
             <div className="-m-1.5 overflow-x-auto">
@@ -47,8 +73,59 @@ const Table = ({ columns, dataSource }: TableProps) => {
                                             className=" hover:bg-light-gray"
                                         >
                                             {Object.keys(data).map((key, index) => {
-                                                if (key === 'id' || key === 'slug' || key === 'key')
-                                                    return null
+                                                if (key === 'id' || key === 'key') return null
+
+                                                if (key === 'slug') {
+                                                    return (
+                                                        <td
+                                                            className="flex gap-4 whitespace-nowrap py-4 px-8"
+                                                            key={index}
+                                                        >
+                                                            <Button
+                                                                usage="toggle-modal"
+                                                                onClick={() =>
+                                                                    openModal(`edit-${data[key]}`)
+                                                                }
+                                                            >
+                                                                <Icons name="table_edit" />
+                                                            </Button>
+                                                            {activeModal === `edit-${data[key]}` &&
+                                                                isOpen && (
+                                                                    <Modal
+                                                                        title={`Assign Role`}
+                                                                        submitLabel="Save"
+                                                                        isOpen={isOpen}
+                                                                        handleSubmit={
+                                                                            handleEditSubmit
+                                                                        }
+                                                                        handleClose={() =>
+                                                                            closeModal(
+                                                                                `edit-${data[key]}`
+                                                                            )
+                                                                        }
+                                                                    >
+                                                                        <form
+                                                                            onSubmit={
+                                                                                handleEditSubmit
+                                                                            }
+                                                                        >
+                                                                            <Dropdown
+                                                                                name=""
+                                                                                label="Select Role"
+                                                                                options={roles}
+                                                                            />
+                                                                        </form>
+                                                                    </Modal>
+                                                                )}
+                                                            <Link
+                                                                className="text-blue-500 hover:text-blue-700"
+                                                                href="#"
+                                                            >
+                                                                <Icons name="table_delete" />
+                                                            </Link>
+                                                        </td>
+                                                    )
+                                                }
 
                                                 return (
                                                     <td
@@ -59,20 +136,6 @@ const Table = ({ columns, dataSource }: TableProps) => {
                                                     </td>
                                                 )
                                             })}
-                                            <td className="flex gap-4 whitespace-nowrap py-4 px-8">
-                                                <Link
-                                                    className="text-blue-500 hover:text-blue-700"
-                                                    href="#"
-                                                >
-                                                    <Icons name="table_edit" />
-                                                </Link>
-                                                <Link
-                                                    className="text-blue-500 hover:text-blue-700"
-                                                    href="#"
-                                                >
-                                                    <Icons name="table_delete" />
-                                                </Link>
-                                            </td>
                                         </tr>
                                     )
                                 })}

--- a/frontend/components/templates/Modal.tsx
+++ b/frontend/components/templates/Modal.tsx
@@ -1,0 +1,91 @@
+import Button from '@/components/atoms/Button'
+import Icons from '@/components/atoms/Icons'
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment } from 'react'
+
+type ModalProps = {
+    title: string
+    children: JSX.Element | string
+    submitLabel: string
+    isOpen: boolean
+    handleSubmit: () => void
+    handleClose: () => void
+}
+
+const Modal = ({
+    title,
+    children,
+    submitLabel,
+    isOpen,
+    handleSubmit,
+    handleClose,
+}: ModalProps): JSX.Element => {
+    return (
+        <Transition appear show={isOpen} as={Fragment}>
+            <Dialog as="div" className="relative z-30" onClose={handleClose}>
+                <Transition.Child
+                    as={Fragment}
+                    enter="ease-out duration-100"
+                    enterFrom="opacity-0"
+                    enterTo="opacity-100"
+                    leave="ease-in duration-100"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
+                >
+                    <div className="fixed inset-0 bg-black bg-opacity-30" />
+                </Transition.Child>
+
+                <div className="fixed inset-0 overflow-y-auto">
+                    <div className="flex min-h-full items-center justify-center p-4 text-center">
+                        <Transition.Child
+                            as={Fragment}
+                            enter="ease-out duration-100"
+                            enterFrom="opacity-0 scale-95"
+                            enterTo="opacity-100 scale-100"
+                            leave="ease-in duration-100"
+                            leaveFrom="opacity-100 scale-100"
+                            leaveTo="opacity-0 scale-95"
+                        >
+                            <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white text-left align-middle shadow-xl transition-all">
+                                <div className="flex justify-between bg-secondary-gray px-6 py-3">
+                                    <Dialog.Title
+                                        as="h3"
+                                        className="text-lg font-medium leading-6 text-gray-900"
+                                    >
+                                        {title}
+                                    </Dialog.Title>
+                                    <Button usage="toggle-modal" onClick={handleClose}>
+                                        <Icons name="x-plain" size="16" />
+                                    </Button>
+                                </div>
+                                <div className="px-6 py-4 ">
+                                    <Dialog.Description className="mt-2 text-sm">
+                                        {children}
+                                    </Dialog.Description>
+                                    <div className="mt-4 flex justify-end gap-2">
+                                        <Button
+                                            type="button"
+                                            usage="modal-cancel"
+                                            onClick={handleClose}
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button
+                                            type="submit"
+                                            usage="modal-submit"
+                                            onClick={handleSubmit}
+                                        >
+                                            {submitLabel}
+                                        </Button>
+                                    </div>
+                                </div>
+                            </Dialog.Panel>
+                        </Transition.Child>
+                    </div>
+                </div>
+            </Dialog>
+        </Transition>
+    )
+}
+
+export default Modal

--- a/frontend/components/templates/Modal.tsx
+++ b/frontend/components/templates/Modal.tsx
@@ -35,7 +35,7 @@ const Modal = ({
                     <div className="fixed inset-0 bg-black bg-opacity-30" />
                 </Transition.Child>
 
-                <div className="fixed inset-0 overflow-y-auto">
+                <div className="overflow-y-inherit fixed inset-0">
                     <div className="flex min-h-full items-center justify-center p-4 text-center">
                         <Transition.Child
                             as={Fragment}
@@ -59,7 +59,11 @@ const Modal = ({
                                     </Button>
                                 </div>
                                 <div className="px-6 py-4 ">
-                                    <Dialog.Description className="mt-2 text-sm">
+                                    <Dialog.Description
+                                        id="modal-content"
+                                        as="div"
+                                        className="mt-2 text-sm"
+                                    >
                                         {children}
                                     </Dialog.Description>
                                     <div className="mt-4 flex justify-end gap-2">
@@ -71,7 +75,7 @@ const Modal = ({
                                             Cancel
                                         </Button>
                                         <Button
-                                            type="submit"
+                                            type="button"
                                             usage="modal-submit"
                                             onClick={handleSubmit}
                                         >

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -23,7 +23,7 @@ const Layout = ({ children }: LayoutProps) => {
         <ProvidersWrapper>
             <main className="relative">
                 {!routeIfLoginPathCheck && (
-                    <div className="fixed z-50 w-full drop-shadow-md">
+                    <div className="fixed z-20 w-full drop-shadow-md">
                         <Navbar />
                     </div>
                 )}

--- a/frontend/pages/teams/[slug]/manage.tsx
+++ b/frontend/pages/teams/[slug]/manage.tsx
@@ -7,6 +7,8 @@ import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import Modal from '@/components/templates/Modal'
+import { useState } from 'react'
 
 const columns: ColumnType[] = [
     {
@@ -71,6 +73,24 @@ const TeamManage = () => {
         })
         return tableList
     }
+
+    const [activeModal, setActiveModal] = useState('')
+    const [isOpen, setIsOpen] = useState(false)
+
+    const handleSubmit = () => {
+        console.log('Submitted!')
+    }
+
+    const openModal = (modal: string) => {
+        setActiveModal(modal)
+        setIsOpen(true)
+    }
+
+    const closeModal = (modal: string) => {
+        setActiveModal(modal)
+        setIsOpen(false)
+    }
+
     return (
         <div className="flex w-full flex-col gap-4 divide-y-2 p-8">
             <h1 className="text-3xl font-bold">{memberList[0].team.name || 'Undefined'}</h1>
@@ -82,7 +102,18 @@ const TeamManage = () => {
                     >
                         {'< Go back'}
                     </Link>
-                    <Button>Add Member</Button>
+                    <Button onClick={() => openModal('add')}>Add Member</Button>
+                    {activeModal === 'add' && isOpen && (
+                        <Modal
+                            title="Add Member"
+                            submitLabel="Add"
+                            isOpen={isOpen}
+                            handleSubmit={handleSubmit}
+                            handleClose={() => closeModal('add')}
+                        >
+                            <div>Test</div>
+                        </Modal>
+                    )}
                 </div>
                 <div className="overflow-hidden border border-black">
                     <Table columns={columns} dataSource={parseGetMembers(memberList)} />

--- a/frontend/pages/teams/[slug]/manage.tsx
+++ b/frontend/pages/teams/[slug]/manage.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/atoms/Button'
+import Dropdown, { OptionType } from '@/components/molecules/Dropdown'
 import Paginate from '@/components/organisms/Paginate'
 import Table, { ColumnType, DataType } from '@/components/organisms/Table'
 import GET_MEMBERS from '@/helpers/graphql/queries/get_members'
@@ -74,11 +75,26 @@ const TeamManage = () => {
         return tableList
     }
 
+    const users: OptionType[] = [
+        { id: 1, name: 'Nicole Amber' },
+        { id: 2, name: 'Keno Renz' },
+        { id: 3, name: 'Jules Russel' },
+        { id: 4, name: 'Ian Michael' },
+        { id: 5, name: 'Kent Nino' },
+        { id: 6, name: 'Kent Michael' },
+    ]
+
+    const roles: OptionType[] = [
+        { id: 1, name: 'FE' },
+        { id: 2, name: 'BE' },
+        { id: 3, name: 'QA' },
+    ]
+
     const [activeModal, setActiveModal] = useState('')
     const [isOpen, setIsOpen] = useState(false)
 
     const handleSubmit = () => {
-        console.log('Submitted!')
+        console.log('member added!')
     }
 
     const openModal = (modal: string) => {
@@ -111,7 +127,22 @@ const TeamManage = () => {
                             handleSubmit={handleSubmit}
                             handleClose={() => closeModal('add')}
                         >
-                            <div>Test</div>
+                            <form onSubmit={handleSubmit} id="add-member-form">
+                                <div className="flex w-full gap-2">
+                                    <Dropdown
+                                        key="user-select"
+                                        name="user"
+                                        label="Select User"
+                                        options={users}
+                                    />
+                                    <Dropdown
+                                        key="role-select"
+                                        name="role"
+                                        label="Select Role"
+                                        options={roles}
+                                    />
+                                </div>
+                            </form>
                         </Modal>
                     )}
                 </div>


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-282

## Commands
none

## Pre-conditions
none

## Expected Output

- [ ] Clicking on `Add Member` button will display the Add Member Form in a modal.
- [ ] Clicking on the `Edit` button in one of the table rows will display the Assign Role Form in a modal.
- [ ] Clicking outside of the modal, on the `X` button in the upper right of the modal, or on the `Cancel` button of the modal will dismiss the modal.

## Notes
none

## Pages Affected
* Manage Team Members page

## Screenshots
_Clicking on Add Member_
<img width="956" alt="image" src="https://user-images.githubusercontent.com/116238730/223063291-5959d63b-dcd2-479e-9a50-17a61cf5b36f.png">

_Clicking on Edit_
<img width="958" alt="image" src="https://user-images.githubusercontent.com/116238730/223063397-79ea7cf8-6654-4b88-bdcd-3417e0b81834.png">
