### PR TITLE
[Overflow-71] [FE] Implement Team Questions API to page

### DIFF
--- a/frontend/components/molecules/DropdownFilters/index.tsx
+++ b/frontend/components/molecules/DropdownFilters/index.tsx
@@ -33,6 +33,7 @@ type Props = {
     triggers: TriggerType[]
     searchKey?: string
     tag?: string
+    team?: string
     refetch: ({ first, page, orderBy, filter }: RefetchType) => Promise<ApolloQueryResult<any>>
 }
 
@@ -43,7 +44,13 @@ const FilterTexts: FilterTextsType = {
     POPULAR: { 1: 'Most Popular', 2: 'Least Popular' },
 }
 
-const DropdownFilters = ({ triggers, searchKey = '', tag = '', refetch }: Props): JSX.Element => {
+const DropdownFilters = ({
+    triggers,
+    searchKey = '',
+    tag = '',
+    team = '',
+    refetch,
+}: Props): JSX.Element => {
     const router = useRouter()
     const [selectedDateFilter, setSelectedDateFilter] = useState(FilterTexts.DATE[1])
     const [selectedAnswerFilter, setSelectedAnswerFilter] = useState(FilterTexts.ANSWER[1])
@@ -97,7 +104,7 @@ const DropdownFilters = ({ triggers, searchKey = '', tag = '', refetch }: Props)
                         refetch({
                             first: 10,
                             page: 1,
-                            filter: { keyword: searchKey, answered: true, tag },
+                            filter: { keyword: searchKey, answered: true, tag, team },
                         })
                         setSelectedAnswerFilter(FilterTexts.ANSWER[1])
                     },
@@ -109,7 +116,7 @@ const DropdownFilters = ({ triggers, searchKey = '', tag = '', refetch }: Props)
                         refetch({
                             first: 10,
                             page: 1,
-                            filter: { keyword: searchKey, answered: false, tag },
+                            filter: { keyword: searchKey, answered: false, tag, team },
                         })
                         setSelectedAnswerFilter(FilterTexts.ANSWER[2])
                     },

--- a/frontend/components/organisms/QuestionList/index.tsx
+++ b/frontend/components/organisms/QuestionList/index.tsx
@@ -40,7 +40,7 @@ const QuestionList = ({
 }: Props): JSX.Element => {
     return (
         <div className="flex w-full flex-row p-5">
-            <div className="flex w-36 flex-col">
+            <div className="flex w-[15%] flex-col">
                 <div className="text-sm">
                     {vote_count} {vote_count !== 1 ? 'Votes' : 'Vote'}
                 </div>
@@ -51,7 +51,7 @@ const QuestionList = ({
                     {view_count} {view_count !== 1 ? 'Views' : 'View'}
                 </div>
             </div>
-            <div className="flex w-full flex-col gap-4">
+            <div className="flex w-[85%] flex-col gap-4">
                 <div className="flex w-full justify-between">
                     <Link
                         href={`/questions/${slug}`}
@@ -70,7 +70,7 @@ const QuestionList = ({
                 </div>
                 <div className="ql-snow flex w-full flex-col gap-1">
                     <div className="ql-editor question-parsed-content w-full">
-                        {parseHTML(content)}
+                        <span className="line-clamp-2">{parseHTML(content)}</span>
                     </div>
                     <div className="mt-[-0.8rem] flex flex-col gap-2">
                         <div className="w-full">

--- a/frontend/components/templates/QuestionPageLayout.tsx
+++ b/frontend/components/templates/QuestionPageLayout.tsx
@@ -33,6 +33,7 @@ interface IProps {
             data: [QuestionType]
         }
     }
+    team?: string
 }
 
 const QuestionsPageLayout = ({
@@ -41,6 +42,7 @@ const QuestionsPageLayout = ({
     searchKey = '',
     isSearchResult = false,
     isPrivate = false,
+    team = '',
 }: IProps): JSX.Element => {
     const router = useRouter()
     const { data: questions, paginatorInfo } = data.questions
@@ -63,6 +65,7 @@ const QuestionsPageLayout = ({
                 <DropdownFilters
                     triggers={['DATE', 'ANSWER']}
                     searchKey={searchKey}
+                    team={team}
                     refetch={refetch}
                 />
             </div>

--- a/frontend/components/templates/QuestionPageLayout.tsx
+++ b/frontend/components/templates/QuestionPageLayout.tsx
@@ -117,7 +117,7 @@ const QuestionsPageLayout = ({
                 ? renderSearchResultHeader()
                 : renderQuestionListHeader()}
             <div className="flex h-full flex-col justify-between">
-                <div className="flex flex-col gap-3 divide-y-2 divide-primary-gray">
+                <div className="flex flex-col gap-3 divide-y-2 divide-primary-gray pl-6">
                     {questionList.map(function (question) {
                         return (
                             <QuestionList

--- a/frontend/pages/questions/index.tsx
+++ b/frontend/pages/questions/index.tsx
@@ -10,7 +10,7 @@ export type RefetchType = {
     first: number
     page: number
     name?: string
-    filter?: { keyword?: string; answered?: boolean; tag?: string }
+    filter?: { keyword?: string; answered?: boolean; tag?: string; team?: string }
     orderBy?: { column: string; order: string }[]
     sort?: { column: string; order: string }[]
 }

--- a/frontend/pages/questions/tagged/[slug].tsx
+++ b/frontend/pages/questions/tagged/[slug].tsx
@@ -46,7 +46,7 @@ const TagsPage = () => {
     }
 
     return (
-        <div className="w-full px-8 py-8">
+        <div className="w-full py-8 pr-8 pl-14">
             <h1 className="mb-6 text-2xl font-bold">
                 Questions tagged with <span className="text-primary-red">{selectedTag}</span>
             </h1>

--- a/frontend/pages/teams/[slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/index.tsx
@@ -7,6 +7,7 @@ import GET_TEAM from '@/helpers/graphql/queries/get_team'
 import { parseHTML } from '@/helpers/htmlParsing'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
+import { RefetchType } from '@/pages/questions'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -140,22 +141,16 @@ const Team = () => {
 }
 
 const QuestionsTab = () => {
-    //Query will be changed
+    const router = useRouter()
+    const { slug } = router.query
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTIONS, {
         variables: {
             first: 10,
             page: 1,
             orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            filter: { answered: true, team: slug as string },
         },
     })
-
-    useEffect(() => {
-        refetch({
-            page: 1,
-            filter: { answered: true, tag: '' },
-            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-        })
-    }, [refetch])
 
     if (loading) return <div></div>
     if (error) {
@@ -164,7 +159,12 @@ const QuestionsTab = () => {
     }
     return (
         <div className="">
-            <QuestionsPageLayout refetch={refetch} data={data} isPrivate={true} />
+            <QuestionsPageLayout
+                refetch={refetch}
+                data={data}
+                isPrivate={true}
+                team={slug as string}
+            />
         </div>
     )
 }

--- a/frontend/pages/teams/[slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/index.tsx
@@ -106,7 +106,7 @@ const Team = () => {
     }
 
     return (
-        <div className="mx-10 mt-10 flex h-full w-full flex-col gap-4">
+        <div className="flex h-full w-full flex-col gap-4 pl-14 pr-10 pt-10">
             <div className="flex flex-row items-center justify-between">
                 <div className="text-2xl font-bold">{team?.name}</div>
                 {isActiveTab === 'questions' && (


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-71

## Commands
1. Go to a team (e.g. `/teams/powlowski-treutel`)
2. Go to `Questions` tab

To manually assign questions to a team, go to Tinker then type:
`App\Models\Question::take(5)->update(['team_id' => 1])`

## Pre-conditions
The team must have questions assigned to it

## Expected Output
- [x] You should be able to fetch questions for a specific team

## Notes
Affected pages could be:
- Teams page
- Questions page

## Screenshots
![image](https://user-images.githubusercontent.com/111732984/223011495-9e00b516-3fdb-4238-9ecf-c709e7d307d9.png)
