### PR TITLE
[Overflow-183] [FE] Integrate API for team dashboard form and team dashboard component

### DIFF
--- a/backend/database/migrations/2023_01_26_040851_create_teams_table.php
+++ b/backend/database/migrations/2023_01_26_040851_create_teams_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('description');
-            $table->longText('dashboard_content');
+            $table->mediumText('dashboard_content');
             $table->foreignId('user_id')->constrained();
             $table->timestamps();
             $table->softDeletes();

--- a/backend/database/migrations/2023_01_26_040851_create_teams_table.php
+++ b/backend/database/migrations/2023_01_26_040851_create_teams_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('description');
-            $table->string('dashboard_content');
+            $table->longText('dashboard_content');
             $table->foreignId('user_id')->constrained();
             $table->timestamps();
             $table->softDeletes();

--- a/frontend/components/molecules/RichTextEditor/index.tsx
+++ b/frontend/components/molecules/RichTextEditor/index.tsx
@@ -52,6 +52,9 @@ const RichTextEditor = ({ value, onChange, id = undefined, usage = 'default' }: 
         case 'description':
             style = { height: '10rem' }
             break
+        case 'dashboard':
+            style = { minHeight: '100%' }
+            break
         case 'content':
             style = { width: '50rem' }
             break
@@ -64,7 +67,7 @@ const RichTextEditor = ({ value, onChange, id = undefined, usage = 'default' }: 
 
     return (
         <ReactQuill
-            className=""
+            className="flex flex-col"
             modules={modules}
             formats={formats}
             onChange={onChange}

--- a/frontend/components/organisms/DashboardEditContentForm/index.tsx
+++ b/frontend/components/organisms/DashboardEditContentForm/index.tsx
@@ -38,6 +38,11 @@ const DashboardEditContentForm = ({ teamId, content, toggleEdit }: Props): JSX.E
         }
 
         setInputError({ ...inputError, content: '' })
+        if (data.content === content) {
+            errorNotify('No changes. Dashboard not updated')
+            toggleEdit()
+            return
+        }
 
         try {
             await updateTeamDashboard({
@@ -73,10 +78,10 @@ const DashboardEditContentForm = ({ teamId, content, toggleEdit }: Props): JSX.E
                 </div>
             </div>
             <form onSubmit={handleSubmit(onSubmit)}>
-                <div className="flex w-full flex-col content-center gap-5 pl-5">
+                <div className="flex w-full flex-col content-center gap-2 pl-5">
                     <div className="text-2xl">Edit Content</div>
                     <div className="flex flex-col">
-                        <div className="flex w-full flex-1 flex-col gap-3 pb-12">
+                        <div className="flex w-full flex-1 flex-col gap-1 pb-12">
                             <label htmlFor="contentInput" className="text-xl font-bold">
                                 Content
                             </label>
@@ -92,10 +97,10 @@ const DashboardEditContentForm = ({ teamId, content, toggleEdit }: Props): JSX.E
                                     />
                                 )}
                             />
+                            <div className="text-sm text-primary-red">{inputError.content}</div>
                         </div>
                     </div>
-                    <div className="mt-[-3rem] flex flex-row items-center justify-between">
-                        <div className="text-sm text-primary-red">{inputError.content}</div>
+                    <div className="mt-[-3rem] flex flex-row justify-end">
                         <Button usage="primary">Update Content</Button>
                     </div>
                 </div>

--- a/frontend/helpers/graphql/mutations/update_team_dashboard.ts
+++ b/frontend/helpers/graphql/mutations/update_team_dashboard.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client'
+
+const UPDATE_TEAM_DASHBOARD = gql`
+    mutation UpdateTeamDashboard($id: ID!, $dashboard_content: String!) {
+        updateTeamDashboard(id: $id, dashboard_content: $dashboard_content) {
+            id
+            dashboard_content
+        }
+    }
+`
+
+export default UPDATE_TEAM_DASHBOARD

--- a/frontend/pages/teams/[slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/index.tsx
@@ -6,6 +6,7 @@ import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
 import GET_TEAM from '@/helpers/graphql/queries/get_team'
 import { parseHTML } from '@/helpers/htmlParsing'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
+import { useBoundStore } from '@/helpers/store'
 import { errorNotify } from '@/helpers/toast'
 import { RefetchType } from '@/pages/questions'
 import { useQuery } from '@apollo/client'
@@ -77,6 +78,10 @@ const Team = () => {
         setDashboardContentEditing(!dashboardContentEditing)
     }
 
+    const isTeamLeader = () => {
+        return team.teamLeader.id === useBoundStore.getState().user_id
+    }
+
     const renderActiveTab = (content: string) => {
         return isActiveTab == 'dashboard' ? (
             <div className="flex w-full flex-col">
@@ -84,19 +89,22 @@ const Team = () => {
                     <DashboardEditContentForm
                         toggleEdit={toggleDashboardContentEdit}
                         content={content}
+                        teamId={team.id}
                     />
                 ) : (
                     <div className="relative w-full">
                         <div className="ql-snow mx-5 my-4">
                             <div className="ql-editor w-full">{parseHTML(content)}</div>
                         </div>
-                        <Button
-                            usage="edit-top-right"
-                            type="button"
-                            onClick={toggleDashboardContentEdit}
-                        >
-                            <Icons name="square_edit" />
-                        </Button>
+                        {isTeamLeader() && (
+                            <Button
+                                usage="edit-top-right"
+                                type="button"
+                                onClick={toggleDashboardContentEdit}
+                            >
+                                <Icons name="square_edit" />
+                            </Button>
+                        )}
                     </div>
                 )}
             </div>

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -31,6 +31,16 @@ const TeamsListPage = () => {
         },
     })
 
+    useEffect(() => {
+        userQuery.refetch({
+            first: 6,
+            page: 1,
+            name: '%%',
+        })
+        setSearchKey('')
+        setTerm('')
+    }, [router, userQuery])
+
     if (userQuery.error) return errorNotify(`Error! ${userQuery.error}`)
 
     const pageInfo: PaginatorInfo = userQuery?.data?.teams.paginatorInfo
@@ -59,16 +69,6 @@ const TeamsListPage = () => {
     const onPageChange = (first: number, page: number) => {
         userQuery.refetch({ first, page })
     }
-
-    useEffect(() => {
-        userQuery.refetch({
-            first: 6,
-            page: 1,
-            name: '%%',
-        })
-        setSearchKey('')
-        setTerm('')
-    }, [router, userQuery.refetch])
 
     return (
         <div className="flex h-full w-full flex-col gap-3 divide-y-2 divide-primary-gray px-10 pt-8 pb-5">


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-183

## Commands
- Please perform `php artisan migrate:fresh --seed`
- Run `php artisan passport:install` then update your client secret in the `.env`
- Go to a team and edit the contents of the dashboard

To reassign a team leader to a team, run this code in tinker:
`Team::find(1)->update(['user_id' => <id>])`

## Pre-conditions
- You should be the Team Leader of team to edit the dashboard

## Expected Output
- [x] You should be able to edit the contents of the team dashboard

## Notes
- I updated the data type of the `dashboard_content` from `string` to `longText`
- Affected Pages could be:
  - Profile Page
  - Add Question Page

## Screenshots
![image](https://user-images.githubusercontent.com/111732984/223336251-77a4e6d4-604c-46c3-83f4-b204dc726e76.png)
