### PR TITLE
[OVERFLOW-279] [OVERFLOW-280] [FE] Implement updated API to Add Question Form and Questions List Page

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateQuestion.php
+++ b/backend/app/GraphQL/Mutations/CreateQuestion.php
@@ -16,12 +16,6 @@ final class CreateQuestion
     {
         $questionData = Arr::except($args, ['tags']);
 
-        $hasNoTeam = ! isset($args['team_id']) || ! $args['team_id'];
-
-        if ($hasNoTeam && (isset($args['is_public']) && ! $args['is_public'])) {
-            throw new CustomException('400', 'Public is required when no team is selected');
-        }
-
         $questionCreate = auth()->user()->questions()->create($questionData);
 
         $questionDetail = Question::find($questionCreate->id);

--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -10,7 +10,7 @@ import {
 import { HiCheck } from 'react-icons/hi2'
 import { IoMdArrowDropup, IoMdArrowDropdown, IoMdCheckmark } from 'react-icons/io'
 import { MdOutlineModeEditOutline, MdModeEditOutline } from 'react-icons/md'
-import { FaTrashAlt } from 'react-icons/fa'
+import { FaTrashAlt, FaLockOpen, FaLock } from 'react-icons/fa'
 import {
     HiChevronDoubleLeft,
     HiChevronDoubleRight,
@@ -97,6 +97,10 @@ const Icons = ({ name, size = '20', additionalClass }: IconsProps): JSX.Element 
             return <HiSearch size="26" />
         case 'x-plain':
             return <HiX size={size} />
+        case 'private':
+            return <FaLock />
+        case 'public':
+            return <FaLockOpen />
         default:
             return <></>
     }

--- a/frontend/components/atoms/ProfileImage/index.tsx
+++ b/frontend/components/atoms/ProfileImage/index.tsx
@@ -18,7 +18,7 @@ const ProfileImage = ({ first_name, last_name, avatar, updated_at }: ProfileImag
                         name={`${first_name} ${last_name}`}
                         size="200"
                         alt={first_name}
-                        src={avatar ? `${avatar}?${updated_at}` : `${first_name}`}
+                        src={avatar ? `${avatar}` : `${avatar}?${updated_at}`}
                         maxInitials={1}
                         textSizeRatio={2}
                     />

--- a/frontend/components/molecules/SortDropdown/index.tsx
+++ b/frontend/components/molecules/SortDropdown/index.tsx
@@ -1,7 +1,7 @@
 import { Menu, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
 import Icons from '@/components/atoms/Icons'
-import { FilterType } from '../../../pages/questions/index'
+import { FilterType } from '@/components/templates/QuestionPageLayout'
 
 type AppProps = {
     grouped?: boolean

--- a/frontend/components/organisms/ProfileInfo/edit.tsx
+++ b/frontend/components/organisms/ProfileInfo/edit.tsx
@@ -114,7 +114,6 @@ const ProfileInfoEdit = ({
 
                     setTimeout(() => {
                         router.reload()
-                        profileRefetchHandler()
                     }, 3000)
                 })
                 .catch((e) => {

--- a/frontend/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/components/organisms/QuestionDetail/index.tsx
@@ -27,6 +27,8 @@ type QuestionDetailProps = {
     is_from_user: boolean
     user_vote: number
     refetchHandler: () => void
+    is_public: boolean
+    team_name?: string
 }
 
 const QuestionDetail = ({
@@ -44,6 +46,8 @@ const QuestionDetail = ({
     is_from_user,
     user_vote,
     refetchHandler,
+    is_public,
+    team_name,
 }: QuestionDetailProps): JSX.Element => {
     const [upsertVote] = useMutation(UPSERT_VOTE)
 
@@ -79,6 +83,19 @@ const QuestionDetail = ({
                             <span className="text-gray-500">
                                 {views_count} {views_count > 1 ? 'times' : 'time'}
                             </span>
+                        </div>
+
+                        {team_name !== '' ? (
+                            <div className="flex gap-1">
+                                <span>From Team </span>
+                                <span className="text-gray-500">{team_name}</span>
+                            </div>
+                        ) : (
+                            ''
+                        )}
+
+                        <div className="flex gap-1">
+                            {is_public ? <Icons name={'public'} /> : <Icons name={'private'} />}
                         </div>
                     </div>
                     <div className="relative flex w-full flex-row justify-between">

--- a/frontend/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/components/organisms/QuestionDetail/index.tsx
@@ -85,18 +85,14 @@ const QuestionDetail = ({
                             </span>
                         </div>
 
-                        {team_name !== '' ? (
+                        {team_name && (
                             <div className="flex gap-1">
                                 <span>From Team </span>
                                 <span className="text-gray-500">{team_name}</span>
                             </div>
-                        ) : (
-                            ''
                         )}
 
-                        <div className="flex gap-1">
-                            {is_public ? <Icons name={'public'} /> : <Icons name={'private'} />}
-                        </div>
+                        <Icons name={is_public ? 'public' : 'private'} />
                     </div>
                     <div className="relative flex w-full flex-row justify-between">
                         <div className="absolute flex w-14 flex-col items-start">

--- a/frontend/components/organisms/QuestionForm/index.tsx
+++ b/frontend/components/organisms/QuestionForm/index.tsx
@@ -43,7 +43,7 @@ const QuestionForm = ({ initialState }: Props): JSX.Element => {
     let title: String | undefined
     let content: String | undefined
     let tags: ITag[] | undefined
-    let is_public: Boolean | undefined
+    let is_public: boolean | undefined
     let team: TeamType | undefined
 
     if (initialState) {
@@ -72,7 +72,7 @@ const QuestionForm = ({ initialState }: Props): JSX.Element => {
             title: title ? String(title) : '',
             description: content ? String(content) : '',
             tags: tags ? tags : [],
-            is_public: is_public ? true : false,
+            is_public,
             team_id: team,
         },
         mode: 'onSubmit',
@@ -217,15 +217,13 @@ const QuestionForm = ({ initialState }: Props): JSX.Element => {
                         <label htmlFor="tagsInput" className="text-2xl">
                             Tags (max. 5)
                         </label>
-                        <div className="">
-                            <Controller
-                                control={control}
-                                name="tags"
-                                render={({ field: { value } }) => (
-                                    <TagsInput setValue={setValue} value={value} />
-                                )}
-                            />
-                        </div>
+                        <Controller
+                            control={control}
+                            name="tags"
+                            render={({ field: { value } }) => (
+                                <TagsInput setValue={setValue} value={value} />
+                            )}
+                        />
                     </div>
                     <div className="flex flex-col  self-center">
                         <label className="text-2xl">Teams</label>

--- a/frontend/components/organisms/QuestionList/index.tsx
+++ b/frontend/components/organisms/QuestionList/index.tsx
@@ -108,15 +108,13 @@ const QuestionList = ({
                                     moment={humanized_created_at}
                                     slug={user?.slug}
                                 />
-                                {team_name !== '' ? (
+                                {team_name && (
                                     <div className="ml-4 text-primary-gray">
                                         From Team :
-                                        <text className="text-blue-600 hover:text-blue-400">
+                                        <text className="ml-2 text-blue-600 hover:text-blue-400">
                                             {team_name}
                                         </text>
                                     </div>
-                                ) : (
-                                    ''
                                 )}
                             </div>
                         </div>

--- a/frontend/components/organisms/QuestionList/index.tsx
+++ b/frontend/components/organisms/QuestionList/index.tsx
@@ -23,6 +23,7 @@ type Props = {
     page_slug?: string
     question_slug?: string
     refetch?: () => void
+    team_name: string
 }
 
 const QuestionList = ({
@@ -41,6 +42,7 @@ const QuestionList = ({
     bookmarkType,
     bookmarkAnswerId,
     page_slug,
+    team_name,
 }: Props): JSX.Element => {
     const renderTeamQuestionDetailHeader = (): JSX.Element => {
         return (
@@ -100,11 +102,23 @@ const QuestionList = ({
                             <Tags values={tags} />
                         </div>
                         <div className="flex flex-row justify-end">
-                            <Author
-                                author={`${user?.first_name} ${user?.last_name}`}
-                                moment={humanized_created_at}
-                                slug={user.slug}
-                            />
+                            <div className="flex flex-col">
+                                <Author
+                                    author={`${user?.first_name} ${user?.last_name}`}
+                                    moment={humanized_created_at}
+                                    slug={user?.slug}
+                                />
+                                {team_name !== '' ? (
+                                    <div className="ml-4 text-primary-gray">
+                                        From Team :
+                                        <text className="text-blue-600 hover:text-blue-400">
+                                            {team_name}
+                                        </text>
+                                    </div>
+                                ) : (
+                                    ''
+                                )}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/frontend/components/templates/QuestionPageLayout.tsx
+++ b/frontend/components/templates/QuestionPageLayout.tsx
@@ -137,6 +137,9 @@ const QuestionsPageLayout = ({
                                 view_count={question.views_count}
                                 tags={question.tags}
                                 user={question.user}
+                                team_name={
+                                    question.team?.name === undefined ? '' : question.team?.name
+                                }
                             />
                         )
                     })}

--- a/frontend/components/templates/QuestionPageLayout.tsx
+++ b/frontend/components/templates/QuestionPageLayout.tsx
@@ -137,9 +137,7 @@ const QuestionsPageLayout = ({
                                 view_count={question.views_count}
                                 tags={question.tags}
                                 user={question.user}
-                                team_name={
-                                    question.team?.name === undefined ? '' : question.team?.name
-                                }
+                                team_name={question.team?.name ?? ''}
                             />
                         )
                     })}

--- a/frontend/components/templates/RouteWrapper.tsx
+++ b/frontend/components/templates/RouteWrapper.tsx
@@ -27,7 +27,9 @@ const RouteWrapper = ({ children }: LayoutProps) => {
             data?.me.last_name,
             data?.me.email,
             data?.me.avatar,
-            data?.me.slug
+            data?.me.slug,
+            data?.me.teams,
+            data?.me.updated_at
         )
 
     if (loading) return <div className="pt-14">{loadingScreenShow()}</div>

--- a/frontend/helpers/graphql/mutations/create_question.ts
+++ b/frontend/helpers/graphql/mutations/create_question.ts
@@ -18,6 +18,15 @@ const CREATE_QUESTION = gql`
             id
             content
             slug
+            is_public
+            tags {
+                id
+                name
+            }
+            team {
+                id
+                name
+            }
         }
     }
 `

--- a/frontend/helpers/graphql/mutations/update_question.ts
+++ b/frontend/helpers/graphql/mutations/update_question.ts
@@ -20,6 +20,15 @@ const UPDATE_QUESTION = gql`
             id
             content
             slug
+            is_public
+            tags {
+                id
+                name
+            }
+            team {
+                id
+                name
+            }
         }
     }
 `

--- a/frontend/helpers/graphql/queries/get_authenticated_user.ts
+++ b/frontend/helpers/graphql/queries/get_authenticated_user.ts
@@ -9,6 +9,13 @@ const GET_AUTHENTICATED_USER = gql`
             email
             avatar
             slug
+            teams {
+                id
+                team {
+                    id
+                    name
+                }
+            }
             updated_at
         }
     }

--- a/frontend/helpers/graphql/queries/get_question.ts
+++ b/frontend/helpers/graphql/queries/get_question.ts
@@ -15,6 +15,11 @@ const GET_QUESTION = gql`
             is_from_user
             is_answered
             user_vote
+            is_public
+            team {
+                id
+                name
+            }
             tags {
                 id
                 name

--- a/frontend/helpers/graphql/queries/get_question_skeleton.ts
+++ b/frontend/helpers/graphql/queries/get_question_skeleton.ts
@@ -8,6 +8,11 @@ const GET_QUESTION_SKELETON = gql`
             content
             slug
             is_from_user
+            is_public
+            team {
+                id
+                name
+            }
             tags {
                 id
                 name

--- a/frontend/helpers/graphql/queries/get_questions.ts
+++ b/frontend/helpers/graphql/queries/get_questions.ts
@@ -26,6 +26,10 @@ const GET_QUESTIONS = gql`
                 humanized_created_at
                 is_from_user
                 is_answered
+                team {
+                    id
+                    name
+                }
                 tags {
                     id
                     name

--- a/frontend/helpers/store.tsx
+++ b/frontend/helpers/store.tsx
@@ -1,5 +1,12 @@
 import { create, StateCreator } from 'zustand'
 
+type TeamType = {
+    id: number
+    team: {
+        id: number
+        name: string
+    }
+}
 interface UserSlice {
     user_id: number
     first_name: string
@@ -7,6 +14,7 @@ interface UserSlice {
     email: string
     avatar: string
     slug: string
+    teams: TeamType[]
     updated_at: string
     setUserID: (
         user_id: number,
@@ -15,6 +23,7 @@ interface UserSlice {
         email: string,
         avatar: string,
         slug: string,
+        teams: TeamType[],
         updated_at: string
     ) => void
 }
@@ -26,8 +35,9 @@ const createUserSlice: StateCreator<UserSlice> = (set) => ({
     email: '',
     avatar: '',
     slug: '',
+    teams: [],
     updated_at: '',
-    setUserID: (user_id, first_name, last_name, email, avatar, slug, updated_at) =>
+    setUserID: (user_id, first_name, last_name, email, avatar, slug, teams, updated_at) =>
         set(() => ({
             user_id,
             first_name,
@@ -35,6 +45,7 @@ const createUserSlice: StateCreator<UserSlice> = (set) => ({
             email,
             avatar,
             slug,
+            teams,
             updated_at,
         })),
 })

--- a/frontend/pages/questions/[slug]/edit.tsx
+++ b/frontend/pages/questions/[slug]/edit.tsx
@@ -21,7 +21,7 @@ const EditQuestionFormPage = () => {
                 </div>
             </div>
             <div className="ml-16 mr-16 w-full content-center lg:w-[80%]">
-                {!loading && <QuestionForm initialState={data.question} />}
+                {!loading && <QuestionForm initialState={data?.question} />}
             </div>
         </div>
     )

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -9,8 +9,8 @@ import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
-import { Fragment, useEffect, useState } from 'react'
-import { FilterType } from '../index'
+import { Fragment, useState } from 'react'
+import { FilterType } from '@/components/templates/QuestionPageLayout'
 
 export type UserType = {
     id?: number
@@ -54,6 +54,11 @@ export type AnswerType = {
     question: { slug: string }
 }
 
+export type TeamType = {
+    id: number
+    name: string
+}
+
 export type QuestionType = {
     id: number
     title: string
@@ -63,6 +68,8 @@ export type QuestionType = {
     vote_count: number
     views_count: number
     humanized_created_at: string
+    is_public: boolean
+    team_name: string
     tags: TagType[]
     is_bookmarked: boolean
     is_from_user: boolean
@@ -71,6 +78,7 @@ export type QuestionType = {
     user: UserType
     answers: AnswerType[]
     comments: CommentType[]
+    team: TeamType
 }
 
 export type AnswerEditType = {
@@ -107,6 +115,8 @@ const QuestionDetailPage = () => {
     const question: QuestionType = {
         ...data.question,
     }
+
+    let team = question.team === null ? '' : question.team.name
 
     const refetchHandler = () => {
         refetch({ shouldAddViewCount: false })
@@ -182,6 +192,8 @@ const QuestionDetailPage = () => {
                         user={question.user}
                         refetchHandler={refetchHandler}
                         is_from_user={question.is_from_user}
+                        is_public={question.is_public}
+                        team_name={team}
                     />
                     <div className="flex flex-col">
                         <div className="flex flex-col divide-y divide-primary-gray">

--- a/frontend/pages/teams/[slug]/manage.tsx
+++ b/frontend/pages/teams/[slug]/manage.tsx
@@ -52,7 +52,6 @@ const TeamManage = () => {
 
     if (loading) return loadingScreenShow()
     if (error) {
-        console.log(error)
         errorNotify(`Error! ${error.message}`)
         router.push(`/teams/${router.query.slug}`)
         return


### PR DESCRIPTION
## Backlog Link

https://framgiaph.backlog.com/view/SUN_OVERFLOW-279
https://framgiaph.backlog.com/view/SUN_OVERFLOW-280

## Commands

## Pre-conditions

## Expected Output
Can add Teams and set status if public or private in creating question
Private questions should not display on the question list page it can be shown on the teams side
Can Update the question if you want to set a team in that question
Default status if public

## Notes

## Screenshots
Question List Page

![image](https://user-images.githubusercontent.com/112840596/223646103-c1b44be4-426a-411a-be25-bca14f3c00bf.png)

Question detail if the user sets a team then the status and the team will display

![image](https://user-images.githubusercontent.com/112840596/223646158-ddb95b17-d5ae-4da8-af04-e755772c023d.png)

Question detail if the user does not set a team then the status will display and the team will not display

![image](https://user-images.githubusercontent.com/112840596/223646221-a43fed32-19c7-470c-b33a-d9c1ff7c89cb.png)
