### PR TITLE
[Overflow-301] [BE] Get team roles API

### DIFF
--- a/backend/graphql/team/query.graphql
+++ b/backend/graphql/team/query.graphql
@@ -7,4 +7,5 @@ extend type Query {
     teamMembers(team_slug: String!): [Member!]
         @guard(with: ["api"])
         @paginate(builder: "App\\GraphQL\\Queries\\TeamMembers")
+    teamRoles: [TeamRole!]! @guard(with: ["api"]) @all
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-301

## Commands
Go to `http://localhost:8000/graphiql`
```
query TeamRoles {
  teamRoles {
    id
    name
    description
  }
}
```

## Pre-conditions
none

## Expected Output
Displays all team roles

## Notes
none

## Screenshots
<img width="498" alt="image" src="https://user-images.githubusercontent.com/116238730/223926959-7ea21ccd-7b47-442f-9332-302c7550bf4a.png">
