### PR TITLE
[OVERFLOW-305] Fix bugs in the User Profile and User Dropdown

### DIFF
--- a/backend/app/GraphQL/Queries/AllUsers.php
+++ b/backend/app/GraphQL/Queries/AllUsers.php
@@ -16,7 +16,7 @@ final class AllUsers
         $users = User::query();
 
         if (isset($args['keyword'])) {
-            $keywordLikeness = '%' . $args['keyword'] . '%';
+            $keywordLikeness = '%'.$args['keyword'].'%';
 
             $users->where(function ($queryLikeness) use ($keywordLikeness) {
                 $queryLikeness

--- a/backend/app/Observers/AnswerObserver.php
+++ b/backend/app/Observers/AnswerObserver.php
@@ -12,25 +12,29 @@ class AnswerObserver
 
     public function created(Answer $answer)
     {
-        UserNotification::create([
-            'user_id' => $answer->question->user_id,
-            'notifiable_type' => 'App\Models\Answer',
-            'notifiable_id' => $answer->id,
-        ]);
+        if (auth()->id != $answer->user_id) {
+            UserNotification::create([
+                'user_id' => $answer->question->user_id,
+                'notifiable_type' => 'App\Models\Answer',
+                'notifiable_id' => $answer->id,
+            ]);
 
-        event(new NotificationEvent($answer->question->user_id));
+            event(new NotificationEvent($answer->question->user_id));
+        }
     }
 
     public function updated(Answer $answer)
     {
         if ($answer->is_correct) {
-            UserNotification::create([
-                'user_id' => $answer->user_id,
-                'notifiable_type' => 'App\Models\Answer',
-                'notifiable_id' => $answer->id,
-            ]);
+            if (auth()->id != $answer->user_id) {
+                UserNotification::create([
+                    'user_id' => $answer->user_id,
+                    'notifiable_type' => 'App\Models\Answer',
+                    'notifiable_id' => $answer->id,
+                ]);
 
-            event(new NotificationEvent($answer->user_id));
+                event(new NotificationEvent($answer->user_id));
+            }
         }
     }
 }

--- a/backend/app/Observers/CommentObserver.php
+++ b/backend/app/Observers/CommentObserver.php
@@ -12,12 +12,14 @@ class CommentObserver
 
     public function created(Comment $comment)
     {
-        UserNotification::create([
-            'user_id' => $comment->commentable->user_id,
-            'notifiable_type' => 'App\Models\Comment',
-            'notifiable_id' => $comment->id,
-        ]);
+        if (auth()->id != $comment->commentable->user_id) {
+            UserNotification::create([
+                'user_id' => $comment->commentable->user_id,
+                'notifiable_type' => 'App\Models\Comment',
+                'notifiable_id' => $comment->id,
+            ]);
 
-        event(new NotificationEvent($comment->commentable->user_id));
+            event(new NotificationEvent($comment->commentable->user_id));
+        }
     }
 }

--- a/frontend/components/molecules/UserDropdown/index.tsx
+++ b/frontend/components/molecules/UserDropdown/index.tsx
@@ -55,7 +55,7 @@ const UserDropdown = ({
                 <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                     <div className="py-1 ">
                         <Menu.Item>
-                            <span className="block px-4 py-2 text-sm font-bold text-gray-900">
+                            <span className="block px-4 py-2 text-sm font-bold text-gray-900 line-clamp-1">
                                 {`${first_name} ${last_name}`}
                             </span>
                         </Menu.Item>

--- a/frontend/components/organisms/AnswerBookmark/index.tsx
+++ b/frontend/components/organisms/AnswerBookmark/index.tsx
@@ -40,6 +40,7 @@ const AnswerBookmark = ({ id, bookmarkable }: BookmarkType): JSX.Element => {
                             View answer
                         </Link>
                         <Author
+                            slug={bookmarkable?.user.slug}
                             author={`${bookmarkable?.user.first_name} ${bookmarkable?.user.last_name}`}
                             moment={bookmarkable?.humanized_created_at}
                         />

--- a/frontend/helpers/graphql/queries/get_bookmarks.ts
+++ b/frontend/helpers/graphql/queries/get_bookmarks.ts
@@ -47,6 +47,7 @@ const GET_BOOKMARKS = gql`
                         user {
                             id
                             first_name
+                            slug
                             last_name
                             avatar
                         }
@@ -63,6 +64,7 @@ const GET_BOOKMARKS = gql`
                             id
                             first_name
                             last_name
+                            slug
                             avatar
                         }
                         question {
@@ -86,6 +88,7 @@ const GET_BOOKMARKS = gql`
                             user {
                                 id
                                 first_name
+                                slug
                                 last_name
                                 avatar
                             }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-305
## Commands
None
## Pre-conditions
None
## Expected Output
- In the Profile - Bookmarks tab, clicking on the username should redirect to that user's profile.
- In the Profile and User Dropdown (Navbar), the username should be truncated if it's too long.
- User should not receive notifications from themselves. (i.e. when commenting on their own question/answer)
## Notes
None
## Screenshots
![image](https://user-images.githubusercontent.com/116168014/224616609-a94abe71-9fe0-4913-a11e-c5155bd2274f.png)
