### PR TITLE
[OVERFLOW-111] - Create API for deleting team

### DIFF
--- a/backend/app/GraphQL/Mutations/DeleteTeam.php
+++ b/backend/app/GraphQL/Mutations/DeleteTeam.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\CustomException;
+use App\Models\Team;
+
+final class DeleteTeam
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $team = Team::find($args['id']);
+
+        if (auth()->user()->role->name != 'Admin') {
+            throw new CustomException('You are not allowed to remove Team');
+        }
+
+        $team->delete();
+
+        return $team;
+    }
+}

--- a/backend/graphql/team/mutation.graphql
+++ b/backend/graphql/team/mutation.graphql
@@ -3,4 +3,5 @@ extend type Mutation {
         id: ID! @rules(apply: ["required", "integer"])
         dashboard_content: String! @rules(apply: ["required"])
     ): Team! @guard(with: ["api"])
+    deleteTeam(id: ID!): Team!
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-111
## Commands
None
## Pre-conditions
None
## Expected Output
If the role of the user is admin then that user "can remove team" if not then that user "cannot remove team"

## Notes

## Screenshots
All Teams, Team 19 will be deleted
![image](https://user-images.githubusercontent.com/112840596/225195728-568ef81a-2c79-497d-b5a8-7677e4d0bc3b.png)

Deleting Team 19 as NOT ADMIN
![image](https://user-images.githubusercontent.com/112840596/225195826-1db2e986-677d-47fe-bb6d-77e76b29fd61.png)

Deleting Team 19 as ADMIN
![image](https://user-images.githubusercontent.com/112840596/225195895-e4b92c2c-18f3-4a48-8a17-2d7615dbcba5.png)

All Teams, Team 19 is removed
![image](https://user-images.githubusercontent.com/112840596/225195953-0f51dc1e-63cb-4ea9-bdf3-df0762ac8bd6.png)
