### PR TITLE
[Overflow-327] [MARKUP] Create Page for Team Detail (Admin)

### DIFF
--- a/frontend/components/atoms/PageStats/index.tsx
+++ b/frontend/components/atoms/PageStats/index.tsx
@@ -1,0 +1,14 @@
+interface StatsProps {
+    label: string
+    value: number
+}
+
+const PageStats = ({ label, value }: StatsProps) => {
+    return (
+        <div className="flex flex-col items-center">
+            <div className="text-center text-lg">{label}</div>
+            <div className="text-md">{value}</div>
+        </div>
+    )
+}
+export default PageStats

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -17,6 +17,7 @@ const Layout = ({ children }: LayoutProps) => {
         '/teams/[slug]/manage',
         '/teams/[slug]/question/[question-slug]',
         '/teams/[slug]/question/[question-slug]/edit',
+        '/manage/teams/[slug]',
     ]
 
     const routeIfLoginPathCheck = router.asPath.includes('login')

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -1,0 +1,85 @@
+import PageStats from '@/components/atoms/PageStats'
+import { useState } from 'react'
+
+interface teamDetails {
+    name: string
+    team_leader: string
+    questions_asked: number
+    questions_answered: number
+    members: number
+}
+
+const team: teamDetails = {
+    name: 'Sun Overflow',
+    team_leader: 'Keno Renz Bacunawa',
+    questions_asked: 20,
+    questions_answered: 5,
+    members: 10,
+}
+
+const getActiveTabClass = (status: boolean): string => {
+    if (status) {
+        return '-mb-[1px] hover:text-primary-red px-6 font-semibold border-b-2 border-primary-red bg-red-100'
+    }
+    return '-mb-[1px] hover:text-primary-red px-6 active:border-red-400'
+}
+
+const TeamDetail = () => {
+    const [activeTab, setActiveTab] = useState('Questions')
+
+    const onClickQuestionsTab = () => {
+        setActiveTab('Questions')
+    }
+
+    const onClickMembersTab = () => {
+        setActiveTab('Members')
+    }
+
+    return (
+        <div className="mx-10 mt-10 w-full flex-col">
+            <div className="flex">
+                <div className="w-full flex-col">
+                    <div className="text-3xl font-medium">{team.name}</div>
+                    <div className="mt-1 text-lg text-secondary-black line-clamp-1">
+                        Handled by: {team.team_leader}
+                    </div>
+                </div>
+                <div className="mx-4 flex w-full flex-row justify-center gap-10 self-start">
+                    <PageStats label="Questions Asked" value={team.questions_asked}></PageStats>
+                    <PageStats
+                        label="Questions Answered"
+                        value={team.questions_answered}
+                    ></PageStats>
+                    <PageStats label="Members" value={team.members}></PageStats>
+                </div>
+            </div>
+            <div className="mt-16 flex h-3/5 flex-col">
+                <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
+                    <div
+                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
+                            activeTab === 'Questions'
+                        )}`}
+                        onClick={onClickQuestionsTab}
+                    >
+                        Questions
+                    </div>
+                    <div
+                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
+                            activeTab === 'Members'
+                        )}`}
+                        onClick={onClickMembersTab}
+                    >
+                        Members
+                    </div>
+                </div>
+                <div className="flex w-full flex-row justify-center">
+                    <div className="w-full pt-8 text-center text-lg font-medium text-primary-gray">
+                        No {activeTab === 'Questions' ? 'Questions' : 'Members'} to Show
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default TeamDetail

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -53,7 +53,7 @@ const TeamDetail = () => {
                     <PageStats label="Members" value={team.members}></PageStats>
                 </div>
             </div>
-            <div className="mt-16 flex h-3/5 flex-col">
+            <div className="mt-10 flex h-3/5 flex-col">
                 <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
                     <div
                         className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-327

## Commands
Go to `http://localhost:3000/manage/teams/slug`

## Pre-conditions
none

## Expected Output
Team Detail page should display the team details such as:
- Team name
- Team leader
- Number of questions asked
- Number of questions answered
- Number of members

The page also displays tabs for Questions and Members.

## Notes
- The content for tabs is on a different story.
- The admin sidebar implementation is on a different story.

## Affected Pages
- Admin Team Detail Page

## Screenshots
<img width="959" alt="image" src="https://user-images.githubusercontent.com/116238730/225220779-f5919c47-a724-4d7c-9492-b1dacabffa92.png">
