### PR TITLE
[OVERFLOW-90] Create API for assigning a role to a user

### DIFF
--- a/backend/app/GraphQL/Mutations/AssignRole.php
+++ b/backend/app/GraphQL/Mutations/AssignRole.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\CustomException;
+use App\Models\Role;
+use App\Models\User;
+
+final class AssignRole
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        if (auth()->user()->role->name != 'Admin') {
+            throw new CustomException('You are not allowed to assign Role');
+        }
+
+        $role = Role::find($args['role_id']);
+        $user = User::find($args['user_id']);
+        $user->update(['role_id' => $role->id]);
+
+        return $user->fresh();
+    }
+}

--- a/backend/graphql/user/mutation.graphql
+++ b/backend/graphql/user/mutation.graphql
@@ -18,4 +18,7 @@ extend type Mutation {
     removeWatchedTag(tag_id: ID!): String!
         @guard(with: ["api"])
         @field(resolver: "RemoveWatchedTag")
+    assignRole(user_id: ID!, role_id: ID): User!
+        @guard(with: ["api"])
+        @field(resolver: "AssignRole")
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-90
## Commands
none
## Pre-conditions
none
## Expected Output
Can assign a role to other users if admin
## Notes
None
## Screenshots
All Users, Update user 16 to role team leader
![image](https://user-images.githubusercontent.com/112840596/225221823-9fa8d51e-8582-467f-a332-a9efc604f282.png)

Admin user, sets user 16 to team leader
![image](https://user-images.githubusercontent.com/112840596/225222064-665e8418-ca45-43ea-84fe-0055a63d4679.png)

Not admin user, sets user 16 to team leader
![image](https://user-images.githubusercontent.com/112840596/225222359-00cb2370-1c1e-4eb4-b8f7-0b50d113a65b.png)

All Users
![image](https://user-images.githubusercontent.com/112840596/225222484-7d82a749-4440-4d85-bc51-7e1f121b3b47.png)

