### PR TITLE
[Overflow-104] [Markup] Create a page for teams (Admin)

### DIFF
--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -27,9 +27,9 @@ type IconsProps = {
 const Icons = ({ name, size = '20', additionalClass }: IconsProps): JSX.Element => {
     switch (name) {
         case 'table_edit':
-            return <MdModeEditOutline size={22} className="fill-primary-red" />
+            return <MdModeEditOutline size={22} className={`fill-primary-red ${additionalClass}`} />
         case 'table_delete':
-            return <HiTrash size={22} className="fill-primary-red" />
+            return <HiTrash size={22} className={`fill-primary-red ${additionalClass}`} />
         case 'square_edit':
             return <HiPencilAlt size="28" className="cursor-pointer fill-primary-red" />
         case 'vote_up':

--- a/frontend/components/molecules/Tooltip/index.tsx
+++ b/frontend/components/molecules/Tooltip/index.tsx
@@ -59,7 +59,10 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
             <div className=" cursor-pointer py-2">
                 <p>
                     {tag.description}
-                    <Link href={`/questions/tagged/${tag.slug}`} className="ml-2 underline ">
+                    <Link
+                        href={`/questions/tagged/${tag.slug}`}
+                        className="ml-2 text-blue-500 underline hover:text-blue-400"
+                    >
                         View Tag
                     </Link>
                 </p>

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -20,8 +20,12 @@ type TableProps = {
     clickableArr?: ClickableType[]
 }
 
-const renderClickable = (text: string, clickable: ClickableType, slug: string = '') => {
-    const handleClick = (e: React.MouseEvent) => {
+const renderClickable = (
+    text: string,
+    clickable: ClickableType,
+    slug: string = ''
+): JSX.Element => {
+    const handleClick = (e: React.MouseEvent): void => {
         e.preventDefault()
         clickable.onClick(slug)
     }
@@ -41,7 +45,7 @@ const Table = ({
     actions,
     isEmptyString = 'No members to show',
     clickableArr = [],
-}: TableProps) => {
+}: TableProps): JSX.Element => {
     return (
         <div className="flex flex-col border-black">
             <div className="-m-1.5 overflow-x-auto">

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -8,13 +8,40 @@ export type DataType = {
     [key: string]: unknown
 }
 
+type ClickableType = {
+    column: string extends 'actions' ? never : string
+    onClick: (slug: string) => void
+}
 type TableProps = {
     columns: ColumnType[]
     dataSource: DataType[]
     actions?: (key: number) => JSX.Element | undefined
+    isEmptyString?: string
+    clickableArr?: ClickableType[]
 }
 
-const Table = ({ columns, dataSource, actions }: TableProps) => {
+const renderClickable = (text: string, clickable: ClickableType, slug: string = '') => {
+    const handleClick = (e: React.MouseEvent) => {
+        e.preventDefault()
+        clickable.onClick(slug)
+    }
+    return (
+        <span
+            className="cursor-pointer text-blue-500 underline hover:text-blue-400"
+            onClick={handleClick}
+        >
+            {text}
+        </span>
+    )
+}
+
+const Table = ({
+    columns,
+    dataSource,
+    actions,
+    isEmptyString = 'No members to show',
+    clickableArr = [],
+}: TableProps) => {
     return (
         <div className="flex flex-col border-black">
             <div className="-m-1.5 overflow-x-auto">
@@ -43,6 +70,9 @@ const Table = ({ columns, dataSource, actions }: TableProps) => {
                                         return (
                                             <tr key={key} className=" hover:bg-light-gray">
                                                 {columns.map((column, key) => {
+                                                    let clickable = clickableArr.find(
+                                                        (item) => item.column === column.key
+                                                    )
                                                     if (column.key === 'action' && actions) {
                                                         return (
                                                             <td
@@ -58,7 +88,13 @@ const Table = ({ columns, dataSource, actions }: TableProps) => {
                                                             key={key}
                                                             className="whitespace-nowrap py-4 pl-16 pr-6 text-sm "
                                                         >
-                                                            {String(data[column.key])}
+                                                            {clickable !== undefined
+                                                                ? renderClickable(
+                                                                      String(data[column.key]),
+                                                                      clickable,
+                                                                      data['slug'] as string
+                                                                  )
+                                                                : String(data[column.key])}
                                                         </td>
                                                     )
                                                 })}
@@ -71,7 +107,7 @@ const Table = ({ columns, dataSource, actions }: TableProps) => {
                                             colSpan={columns.length}
                                             className="w-full py-10 text-center text-lg font-bold text-primary-gray"
                                         >
-                                            No members to show
+                                            {isEmptyString}
                                         </td>
                                     </tr>
                                 )}

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -18,7 +18,6 @@ const Layout = ({ children }: LayoutProps) => {
         '/teams/[slug]/question/[question-slug]',
         '/teams/[slug]/question/[question-slug]/edit',
         '/manage/teams/[slug]',
-        '/manage',
         '/manage/teams',
     ]
 

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -18,6 +18,8 @@ const Layout = ({ children }: LayoutProps) => {
         '/teams/[slug]/question/[question-slug]',
         '/teams/[slug]/question/[question-slug]/edit',
         '/manage/teams/[slug]',
+        '/manage',
+        '/manage/teams',
     ]
 
     const routeIfLoginPathCheck = router.asPath.includes('login')

--- a/frontend/pages/manage/index.tsx
+++ b/frontend/pages/manage/index.tsx
@@ -1,0 +1,4 @@
+const AdminPage = () => {
+    return <div>AdminPage</div>
+}
+export default AdminPage

--- a/frontend/pages/manage/index.tsx
+++ b/frontend/pages/manage/index.tsx
@@ -1,4 +1,0 @@
-const AdminPage = () => {
-    return <div>AdminPage</div>
-}
-export default AdminPage

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -61,20 +61,20 @@ const tempPaginateProps = {
     currentPage: 1,
     lastPage: 2,
     hasMorePages: true,
-    onPageChange: () => console.log('next'),
+    onPageChange: (): void => console.log('next'),
 }
 
-const handleEdit = (event: React.MouseEvent<HTMLElement>) => console.log('Edit')
-const handleDelete = (event: React.MouseEvent<HTMLElement>) => console.log('Delete')
+const handleEdit = (event: React.MouseEvent<HTMLElement>): void => console.log('Edit')
+const handleDelete = (event: React.MouseEvent<HTMLElement>): void => console.log('Delete')
 
-const editAction = (key: number) => {
+const editAction = (key: number): JSX.Element => {
     return (
         <div onClick={handleEdit}>
             <Icons name="table_edit" additionalClass="fill-gray-500" />
         </div>
     )
 }
-const deleteAction = (key: number) => {
+const deleteAction = (key: number): JSX.Element => {
     return (
         <div onClick={handleDelete}>
             <Icons name="table_delete" additionalClass="fill-gray-500" />
@@ -91,12 +91,12 @@ const renderTeamsActions = (key: number): JSX.Element | undefined => {
     )
 }
 
-const AdminTeams = () => {
+const AdminTeams = (): JSX.Element => {
     const router = useRouter()
     const clickableArr = [
         {
             column: 'name',
-            onClick: (slug: string) => {
+            onClick: (slug: string): void => {
                 router.push({
                     pathname: '/admin/teams/[slug]', //Change to Proper URL
                     query: { slug },

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -1,0 +1,126 @@
+import Button from '@/components/atoms/Button'
+import Icons from '@/components/atoms/Icons'
+import Paginate from '@/components/organisms/Paginate'
+import Table, { ColumnType } from '@/components/organisms/Table'
+import { useRouter } from 'next/router'
+
+const columns: ColumnType[] = [
+    {
+        title: 'Team Name',
+        key: 'name',
+    },
+    {
+        title: 'Description',
+        key: 'description',
+    },
+    {
+        title: 'Members',
+        key: 'members_count',
+    },
+    {
+        title: '',
+        key: 'action',
+        width: 20,
+    },
+]
+
+const tempData = [
+    {
+        name: 'ABCD',
+        description: 'a',
+        members_count: 10,
+        slug: 'abcd',
+    },
+    {
+        name: 'ABCD',
+        description: 'a',
+        members_count: 10,
+        slug: 'abcd',
+    },
+    {
+        name: 'ABCD',
+        description: 'a',
+        members_count: 10,
+        slug: 'abcd',
+    },
+    {
+        name: 'ABCD',
+        description: 'a',
+        members_count: 10,
+        slug: 'abcd',
+    },
+    {
+        name: 'ABCD',
+        description: 'a',
+        members_count: 10,
+        slug: 'abcd',
+    },
+]
+
+const tempPaginateProps = {
+    currentPage: 1,
+    lastPage: 2,
+    hasMorePages: true,
+    onPageChange: () => console.log('next'),
+}
+
+const handleEdit = (event: React.MouseEvent<HTMLElement>) => console.log('Edit')
+const handleDelete = (event: React.MouseEvent<HTMLElement>) => console.log('Delete')
+
+const editAction = (key: number) => {
+    return (
+        <div onClick={handleEdit}>
+            <Icons name="table_edit" additionalClass="fill-gray-500" />
+        </div>
+    )
+}
+const deleteAction = (key: number) => {
+    return (
+        <div onClick={handleDelete}>
+            <Icons name="table_delete" additionalClass="fill-gray-500" />
+        </div>
+    )
+}
+
+const renderTeamsActions = (key: number): JSX.Element | undefined => {
+    return (
+        <div className="flex flex-row gap-4">
+            {editAction(key)}
+            {deleteAction(key)}
+        </div>
+    )
+}
+
+const AdminTeams = () => {
+    const router = useRouter()
+    const clickableArr = [
+        {
+            column: 'name',
+            onClick: (slug: string) => {
+                router.push({
+                    pathname: '/admin/teams/[slug]', //Change to Proper URL
+                    query: { slug },
+                })
+            },
+        },
+    ]
+    return (
+        <div className="mx-10 mt-[10vh] flex w-full flex-col gap-8">
+            <div className="flex flex-row justify-between">
+                <div className="text-lg font-semibold">Teams</div>
+                <Button type="button">New Team</Button>
+            </div>
+            <div className="TableContainer">
+                <Table
+                    columns={columns}
+                    dataSource={tempData}
+                    isEmptyString="No Teams to Show"
+                    actions={renderTeamsActions}
+                    clickableArr={clickableArr}
+                />
+                <Paginate {...tempPaginateProps} />
+            </div>
+        </div>
+    )
+}
+export default AdminTeams

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -107,10 +107,12 @@ const AdminTeams = (): JSX.Element => {
     return (
         <div className="mx-10 mt-[10vh] flex w-full flex-col gap-8">
             <div className="flex flex-row justify-between">
-                <div className="text-lg font-semibold">Teams</div>
-                <Button type="button">New Team</Button>
+                <div className="text-3xl font-bold">Teams</div>
+                <Button type="button" additionalClass="px-6 py-3">
+                    New Team
+                </Button>
             </div>
-            <div className="TableContainer">
+            <div className="TableContainer border-2 border-[#555555]">
                 <Table
                     columns={columns}
                     dataSource={tempData}
@@ -118,8 +120,8 @@ const AdminTeams = (): JSX.Element => {
                     actions={renderTeamsActions}
                     clickableArr={clickableArr}
                 />
-                <Paginate {...tempPaginateProps} />
             </div>
+            <Paginate {...tempPaginateProps} />
         </div>
     )
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-104
## Commands

## Pre-conditions
## Expected Output
A Teams Table in `/admin/teams`
Team name should be able to redirect to another page
Two actions such as Edit and Delete are found per row
A `New Team` Button on top top right of the table
A Pagination Component on the bottom of the table
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/225531186-55b16d1b-7f14-423c-b016-bcb2c66b6511.png)


## Affected Pages
`/manage/teams`
`/teams/[slug]/manage`