### PR TITLE
[Overflow-96] [MARKUP] Create form and Implement modal for add/edit tags

### DIFF
--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -1,0 +1,51 @@
+// import FormAlert from "@/components/molecules/FormAlert"
+// import { errorNotify, successNotify } from '@/helpers/toast'
+import Modal from '@/components/templates/Modal'
+const tempData = {
+    title: '',
+    description: '',
+}
+type FormProps = {
+    initialData?: {
+        title: string
+        description: string
+    }
+    closeModal: () => void
+    isOpen: boolean
+}
+
+const TagsFormModal = ({ initialData = tempData, isOpen, closeModal }: FormProps): JSX.Element => {
+    const formTitle = initialData?.title ? 'Edit Tag' : 'Add Tag'
+    return (
+        <Modal
+            title={formTitle}
+            submitLabel={formTitle}
+            isOpen={isOpen}
+            handleClose={() => {
+                closeModal()
+            }}
+        >
+            <form className="flex w-full flex-col gap-4 ">
+                <div className="flex flex-col gap-2">
+                    <input
+                        type="text"
+                        id="tagTitle"
+                        className="rounded-lg"
+                        placeholder="Title"
+                        defaultValue={initialData.title || ''}
+                    />
+                </div>
+                <div className="flex flex-col gap-2">
+                    <textarea
+                        id="tagDescription"
+                        className="rounded-lg"
+                        placeholder="Briefly Describe the Tag"
+                        defaultValue={initialData.description || ''}
+                        rows={4}
+                    />
+                </div>
+            </form>
+        </Modal>
+    )
+}
+export default TagsFormModal

--- a/frontend/pages/test/tagsform.tsx
+++ b/frontend/pages/test/tagsform.tsx
@@ -1,13 +1,10 @@
 import Button from '@/components/atoms/Button'
 import TagsFormModal from '@/components/organisms/TagsFormModal'
 import { useState } from 'react'
-//Test Page for the Component
-const TagsFormPage = () => {
+//  Test Page for the Component
+const TagsFormPage = (): JSX.Element => {
     const [isOpen, setIsOpen] = useState<boolean>(false)
-    const handleSubmit = () => {
-        setIsOpen(false)
-    }
-    const closeModal = () => {
+    const closeModal = (): void => {
         setIsOpen(false)
     }
     const tempData = {
@@ -18,7 +15,13 @@ const TagsFormPage = () => {
     return (
         <div className="m-20 ">
             <div className="">
-                <Button onClick={() => setIsOpen(true)}>Test</Button>
+                <Button
+                    onClick={() => {
+                        setIsOpen(true)
+                    }}
+                >
+                    Test
+                </Button>
             </div>
             <TagsFormModal isOpen={isOpen} closeModal={closeModal} initialData={tempData} />
         </div>

--- a/frontend/pages/test/tagsform.tsx
+++ b/frontend/pages/test/tagsform.tsx
@@ -1,0 +1,27 @@
+import Button from '@/components/atoms/Button'
+import TagsFormModal from '@/components/organisms/TagsFormModal'
+import { useState } from 'react'
+//Test Page for the Component
+const TagsFormPage = () => {
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const handleSubmit = () => {
+        setIsOpen(false)
+    }
+    const closeModal = () => {
+        setIsOpen(false)
+    }
+    const tempData = {
+        title: '123',
+        description: '1234',
+    }
+
+    return (
+        <div className="m-20 ">
+            <div className="">
+                <Button onClick={() => setIsOpen(true)}>Test</Button>
+            </div>
+            <TagsFormModal isOpen={isOpen} closeModal={closeModal} initialData={tempData} />
+        </div>
+    )
+}
+export default TagsFormPage


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-96
## Commands

## Pre-conditions

## Expected Output
in `/test/tagsfrom` clicking a there is a button that toggles a Modal that contains a form for Add/Edit Tag
putting an initalData prop in TagsFormModal would change the Modal Title to Edit Tag otherwise it's Add Tag

## Notes
There is no wireframes for this task as we changed from having a page for it to becoming a modal

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/225280999-395f0f00-a46f-4137-8253-2e454e0463fd.png)

![image](https://user-images.githubusercontent.com/114897466/225280935-8ba44cc4-ee9d-4300-a23e-ba000afe20c6.png)


