### PR TITLE
[Overflow-328] [FE] Implement Get Team API to Team Detail Page (Admin)

### DIFF
--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -36,7 +36,7 @@ class Team extends Model
         });
     }
 
-    protected $appends = ['members_count', 'is_team_leader'];
+    protected $appends = ['members_count', 'is_team_leader', 'questions_asked', 'questions answered'];
 
     protected $guarded = [];
 
@@ -50,6 +50,11 @@ class Team extends Model
         return $this->hasMany(Member::class);
     }
 
+    public function questions()
+    {
+        return $this->hasMany(Question::class);
+    }
+
     public function getMembersCountAttribute()
     {
         return $this->members()->count();
@@ -58,5 +63,15 @@ class Team extends Model
     public function getIsTeamLeaderAttribute()
     {
         return $this->teamLeader->id === Auth::id();
+    }
+
+    public function getQuestionsAskedAttribute()
+    {
+        return $this->questions()->where('team_id', $this->id)->count();
+    }
+
+    public function getQuestionsAnsweredAttribute()
+    {
+        return $this->questions()->where('team_id', $this->id)->has('answers')->count();
     }
 }

--- a/backend/graphql/team/type.graphql
+++ b/backend/graphql/team/type.graphql
@@ -10,6 +10,8 @@ type Team {
     slug: String!
     members_count: Int!
     is_team_leader: Boolean!
+    questions_asked: Int!
+    questions_answered: Int!
 }
 
 type TeamRole {

--- a/frontend/helpers/graphql/queries/get_team.ts
+++ b/frontend/helpers/graphql/queries/get_team.ts
@@ -7,6 +7,9 @@ const GET_TEAM = gql`
             name
             description
             dashboard_content
+            members_count
+            questions_asked
+            questions_answered
             teamLeader {
                 id
                 slug

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -1,20 +1,24 @@
 import PageStats from '@/components/atoms/PageStats'
+import GET_TEAM from '@/helpers/graphql/queries/get_team'
 import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { useQuery } from '@apollo/client'
+import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
+import { errorNotify } from '@/helpers/toast'
 
-interface teamDetails {
-    name: string
-    team_leader: string
-    questions_asked: number
-    questions_answered: number
-    members: number
+interface UserType {
+    id: number
+    first_name: string
+    last_name: string
 }
 
-const team: teamDetails = {
-    name: 'Sun Overflow',
-    team_leader: 'Keno Renz Bacunawa',
-    questions_asked: 20,
-    questions_answered: 5,
-    members: 10,
+interface TeamType {
+    id: number
+    name: string
+    teamLeader: UserType
+    members_count: number
+    questions_asked: number
+    questions_answered: number
 }
 
 const getActiveTabClass = (status: boolean): string => {
@@ -24,14 +28,28 @@ const getActiveTabClass = (status: boolean): string => {
     return '-mb-[1px] hover:text-primary-red px-6 active:border-red-400'
 }
 
-const TeamDetail = () => {
-    const [activeTab, setActiveTab] = useState('Questions')
+const TeamDetail = (): JSX.Element => {
+    const router = useRouter()
+    const [activeTab, setActiveTab] = useState<string>('Questions')
 
-    const onClickQuestionsTab = () => {
+    const { data, loading, error, refetch } = useQuery(GET_TEAM, {
+        variables: { slug: router.query.slug },
+    })
+
+    const team: TeamType = data?.team
+    const teamLeader: UserType = team?.teamLeader
+
+    if (loading) return loadingScreenShow()
+    if (error) {
+        errorNotify(`Error! ${error}`)
+        return <></>
+    }
+
+    const onClickQuestionsTab = (): void => {
         setActiveTab('Questions')
     }
 
-    const onClickMembersTab = () => {
+    const onClickMembersTab = (): void => {
         setActiveTab('Members')
     }
 
@@ -39,18 +57,18 @@ const TeamDetail = () => {
         <div className="mx-10 mt-10 w-full flex-col">
             <div className="flex">
                 <div className="w-full flex-col">
-                    <div className="text-3xl font-medium">{team.name}</div>
+                    <div className="text-3xl font-medium">{team?.name}</div>
                     <div className="mt-1 text-lg text-secondary-black line-clamp-1">
-                        Handled by: {team.team_leader}
+                        {`Handled by: ${teamLeader?.first_name} ${teamLeader?.last_name}`}
                     </div>
                 </div>
                 <div className="mx-4 flex w-full flex-row justify-center gap-10 self-start">
-                    <PageStats label="Questions Asked" value={team.questions_asked}></PageStats>
+                    <PageStats label="Questions Asked" value={team?.questions_asked}></PageStats>
                     <PageStats
                         label="Questions Answered"
-                        value={team.questions_answered}
+                        value={team?.questions_answered}
                     ></PageStats>
-                    <PageStats label="Members" value={team.members}></PageStats>
+                    <PageStats label="Members" value={team?.members_count}></PageStats>
                 </div>
             </div>
             <div className="mt-10 flex h-3/5 flex-col">


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-328

## Commands
Go to `http://localhost:3000/manage/teams/slug`

## Pre-conditions
none

## Expected Output
Team Detail page will display details about team.

## Affected Pages
- Team Detail (Admin)

Also checked for any side effects in:
- Teams Page
- Team Detail

## Notes
none

## Screenshots
<img width="959" alt="image" src="https://user-images.githubusercontent.com/116238730/225494824-80a30c60-52ae-4b97-8a12-cadcdc0c43d9.png">
