### PR TITLE
[Overflow-112] [FE] Implement API to admin teams page

### DIFF
--- a/frontend/components/molecules/CustomComboBox/index.tsx
+++ b/frontend/components/molecules/CustomComboBox/index.tsx
@@ -2,7 +2,6 @@ import { Combobox, Transition } from '@headlessui/react'
 import type { Dispatch, SetStateAction } from 'react'
 import React, { Fragment, useState } from 'react'
 import { HiCheck } from 'react-icons/hi2'
-
 export interface ITag {
     id: number
     name: string
@@ -49,7 +48,7 @@ const CustomCombobox = ({
                         id="comboBoxInput"
                         placeholder={placeholder}
                         className={`w-0 grow text-sm leading-5 text-gray-900 focus:ring-0 ${extraInputClasses}`}
-                        onChange={(event) => {
+                        onChange={(event): void => {
                             setQueryText(event.target.value)
                         }}
                         onKeyDown={(e: React.KeyboardEvent): void => {

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -1,10 +1,10 @@
 import PageStats from '@/components/atoms/PageStats'
 import GET_TEAM from '@/helpers/graphql/queries/get_team'
-import { useState } from 'react'
-import { useRouter } from 'next/router'
-import { useQuery } from '@apollo/client'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
+import { useQuery } from '@apollo/client'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 
 interface UserType {
     id: number

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -109,7 +109,7 @@ const AdminTeams = (): JSX.Element => {
             column: 'name',
             onClick: (slug: string): void => {
                 void router.push({
-                    pathname: '/admin/teams/[slug]',
+                    pathname: '/manage/teams/[slug]',
                     query: { slug },
                 })
             },

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -1,9 +1,32 @@
 import Button from '@/components/atoms/Button'
 import Icons from '@/components/atoms/Icons'
 import Paginate from '@/components/organisms/Paginate'
-import Table from '@/components/organisms/Table'
 import type { ColumnType } from '@/components/organisms/Table'
+import Table from '@/components/organisms/Table'
+import GET_TEAMS from '@/helpers/graphql/queries/get_teams'
+import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
+import { errorNotify } from '@/helpers/toast'
+import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
+
+type TeamType = {
+    id: number
+    name: string
+    slug: string
+    description: string
+    members_count: string
+}
+
+type TeamsQuery = {
+    teams: {
+        data: TeamType[]
+        paginatorInfo: {
+            currentPage: number
+            hasMorePages: boolean
+            lastPage: number
+        }
+    }
+}
 
 const columns: ColumnType[] = [
     {
@@ -24,48 +47,6 @@ const columns: ColumnType[] = [
         width: 20,
     },
 ]
-
-const tempData = [
-    {
-        name: 'ABCD',
-        description: 'a',
-        members_count: 10,
-        slug: 'abcd',
-    },
-    {
-        name: 'ABCD',
-        description: 'a',
-        members_count: 10,
-        slug: 'abcd',
-    },
-    {
-        name: 'ABCD',
-        description: 'a',
-        members_count: 10,
-        slug: 'abcd',
-    },
-    {
-        name: 'ABCD',
-        description: 'a',
-        members_count: 10,
-        slug: 'abcd',
-    },
-    {
-        name: 'ABCD',
-        description: 'a',
-        members_count: 10,
-        slug: 'abcd',
-    },
-]
-
-const tempPaginateProps = {
-    currentPage: 1,
-    lastPage: 2,
-    hasMorePages: true,
-    onPageChange: (): void => {
-        console.log('next')
-    },
-}
 
 const handleEdit = (event: React.MouseEvent<HTMLElement>): void => {
     console.log('Edit')
@@ -100,6 +81,29 @@ const renderTeamsActions = (key: number): JSX.Element | undefined => {
 
 const AdminTeams = (): JSX.Element => {
     const router = useRouter()
+
+    const { data, loading, error, refetch } = useQuery<TeamsQuery>(GET_TEAMS, {
+        variables: {
+            first: 6,
+            page: 1,
+        },
+    })
+
+    const onPageChange = async (first: number, page: number): Promise<void> => {
+        await refetch({ first, page })
+    }
+
+    if (loading) return loadingScreenShow()
+    if (error) {
+        errorNotify(`Error! ${error.message}`)
+        return <></>
+    }
+
+    const { data: teamArr, paginatorInfo } = data?.teams ?? {
+        data: [],
+        paginatorInfo: { currentPage: 1, hasMorePages: false, lastPage: 1 },
+    }
+
     const clickableArr = [
         {
             column: 'name',
@@ -112,23 +116,23 @@ const AdminTeams = (): JSX.Element => {
         },
     ]
     return (
-        <div className="mx-10 mt-[10vh] flex w-full flex-col gap-8">
-            <div className="flex flex-row justify-between">
-                <div className="text-3xl font-bold">Teams</div>
+        <div className="flex h-full w-full flex-col gap-4 bg-slate-500 p-8">
+            <div className="mt-4 flex flex-row items-center justify-between">
+                <h1 className="text-3xl font-bold">Teams</h1>
                 <Button type="button" additionalClass="px-6 py-3">
                     New Team
                 </Button>
             </div>
-            <div className="TableContainer border-2 border-[#555555]">
+            <div className="TableContainer overflow-hidden border border-[#555555]">
                 <Table
                     columns={columns}
-                    dataSource={tempData}
+                    dataSource={teamArr}
                     isEmptyString="No Teams to Show"
                     actions={renderTeamsActions}
                     clickableArr={clickableArr}
                 />
             </div>
-            <Paginate {...tempPaginateProps} />
+            <Paginate {...paginatorInfo} onPageChange={onPageChange} />
         </div>
     )
 }

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -116,7 +116,7 @@ const AdminTeams = (): JSX.Element => {
         },
     ]
     return (
-        <div className="flex h-full w-full flex-col gap-4 bg-slate-500 p-8">
+        <div className="flex h-full w-full flex-col gap-4 p-8">
             <div className="mt-4 flex flex-row items-center justify-between">
                 <h1 className="text-3xl font-bold">Teams</h1>
                 <Button type="button" additionalClass="px-6 py-3">

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -132,7 +132,9 @@ const AdminTeams = (): JSX.Element => {
                     clickableArr={clickableArr}
                 />
             </div>
-            <Paginate {...paginatorInfo} onPageChange={onPageChange} />
+            <div className="mt-auto">
+                <Paginate {...paginatorInfo} onPageChange={onPageChange} />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-112
## Commands

## Pre-conditions

## Expected Output
* Working Pagination
* Clicking Team names should redirect to the details page on `/manage/teams/[slug]`
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/225577712-bfb6d33f-64f3-4b4d-aa22-737059b570bb.png)
