### PR TITLE
[Overflow-78] [Overflow-79] [BE] Retrieve role and permissions API

### DIFF
--- a/backend/app/GraphQL/Directives/HasPermissionsDirective.php
+++ b/backend/app/GraphQL/Directives/HasPermissionsDirective.php
@@ -53,7 +53,7 @@ GRAPHQL;
                 }
 
                 $user = $context->user();
-                $permissions = $user->role->permissions->pluck('name')->toArray();
+                $permissions = $user->role->permissions->pluck('slug')->toArray();
 
                 if (
                     // Unauthenticated users don't get to see anything

--- a/backend/app/GraphQL/Queries/Role.php
+++ b/backend/app/GraphQL/Queries/Role.php
@@ -2,9 +2,9 @@
 
 namespace App\GraphQL\Queries;
 
-use App\Models\Member;
+use App\Models\Role as ModelsRole;
 
-final class UserTeams
+final class Role
 {
     /**
      * @param  null  $_
@@ -12,8 +12,6 @@ final class UserTeams
      */
     public function __invoke($_, array $args)
     {
-        $members = Member::where('user_id', $args['id']);
-
-        return $members;
+        return ModelsRole::where('slug', $args['slug'])->first();
     }
 }

--- a/backend/app/Models/Permission.php
+++ b/backend/app/Models/Permission.php
@@ -5,12 +5,26 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Permission extends Model
 {
     use HasFactory, SoftDeletes;
 
     protected $guarded = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($permission) {
+            $permission->slug = Str::slug($permission->name);
+        });
+
+        static::updating(function ($permission) {
+            $permission->slug = Str::slug($permission->name);
+        });
+    }
 
     public function roles()
     {

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -5,12 +5,26 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Role extends Model
 {
     use HasFactory, SoftDeletes;
 
     protected $guarded = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($role) {
+            $role->slug = Str::slug($role->name);
+        });
+
+        static::updating(function ($role) {
+            $role->slug = Str::slug($role->name);
+        });
+    }
 
     public function users()
     {

--- a/backend/database/migrations/2023_03_17_110015_add_slug_to_permissions.php
+++ b/backend/database/migrations/2023_03_17_110015_add_slug_to_permissions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->string('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/backend/database/migrations/2023_03_17_130822_add_slug_to_roles.php
+++ b/backend/database/migrations/2023_03_17_130822_add_slug_to_roles.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/backend/database/seeders/PermissionSeeder.php
+++ b/backend/database/seeders/PermissionSeeder.php
@@ -19,119 +19,142 @@ class PermissionSeeder extends Seeder
             [
                 'id' => 1,
                 'name' => 'Add question',
+                'slug' => 'add-question',
                 'description' => 'Can ask a question',
             ],
             [
                 'id' => 2,
                 'name' => 'Edit question',
+                'slug' => 'edit-question',
                 'description' => 'Can edit own question',
             ],
             [
                 'id' => 3,
                 'name' => 'Delete question',
+                'slug' => 'delete-question',
                 'description' => 'Can delete own question',
             ],
             [
                 'id' => 4,
                 'name' => 'View question',
+                'slug' => 'view-question',
                 'description' => 'Can view a question',
             ],
             [
                 'id' => 5,
                 'name' => 'Add role',
+                'slug' => 'add-role',
                 'description' => 'Can add a role',
             ],
             [
                 'id' => 6,
                 'name' => 'Edit role',
+                'slug' => 'edit-role',
                 'description' => 'Can edit a role',
             ],
             [
                 'id' => 7,
                 'name' => 'Delete role',
+                'slug' => 'delete-role',
                 'description' => 'Can delete a role',
             ],
             [
                 'id' => 8,
                 'name' => 'View role',
+                'slug' => 'view-role',
                 'description' => 'Can view a role',
             ],
             [
                 'id' => 9,
                 'name' => 'Assign role',
+                'slug' => 'assign-role',
                 'description' => 'Can assign a role',
             ],
             [
                 'id' => 10,
                 'name' => 'Vote question',
+                'slug' => 'vote-question',
                 'description' => 'Can vote a question',
             ],
             [
                 'id' => 11,
                 'name' => 'Vote answer',
+                'slug' => 'vote-answer',
                 'description' => 'Can vote an answer',
             ],
             [
                 'id' => 12,
                 'name' => 'Add answer',
+                'slug' => 'add-answer',
                 'description' => 'Can add an answer',
             ],
             [
                 'id' => 13,
                 'name' => 'Edit answer',
+                'slug' => 'edit-answer',
                 'description' => 'Can edit own answer',
             ],
             [
                 'id' => 14,
                 'name' => 'Delete answer',
+                'slug' => 'delete-answer',
                 'description' => 'Can delete own answer',
             ],
             [
                 'id' => 15,
                 'name' => 'Add comment',
+                'slug' => 'add-comment',
                 'description' => 'Can add a comment',
             ],
             [
                 'id' => 16,
                 'name' => 'Edit comment',
+                'slug' => 'edit-comment',
                 'description' => 'Can edit own comment',
             ],
             [
                 'id' => 17,
                 'name' => 'Delete comment',
+                'slug' => 'delete-comment',
                 'description' => 'Can delete own comment',
             ],
             [
                 'id' => 18,
                 'name' => 'Add team',
+                'slug' => 'add-team',
                 'description' => 'Can add a team',
             ],
             [
                 'id' => 19,
                 'name' => 'Edit team',
+                'slug' => 'edit-team',
                 'description' => 'Can edit own team',
             ],
             [
                 'id' => 20,
                 'name' => 'Delete team',
+                'slug' => 'delete-team',
                 'description' => 'Can delete own team',
             ],
             [
                 'id' => 21,
                 'name' => 'Add team role',
+                'slug' => 'add-team-role',
                 'description' => 'Can add a team role',
             ],
             [
                 'id' => 22,
                 'name' => 'Edit team role',
+                'slug' => 'edit-team-role',
                 'description' => 'Can edit own team role',
             ],
             [
                 'id' => 23,
                 'name' => 'Delete team role',
+                'slug' => 'delete-team-role',
                 'description' => 'Can delete own team role',
             ],
-        ], ['id'], ['name', 'description']);
+        ], ['id'], ['name', 'slug', 'description']);
 
         $admin = Role::find(1);
         $teamLead = Role::find(2);

--- a/backend/database/seeders/RoleSeeder.php
+++ b/backend/database/seeders/RoleSeeder.php
@@ -18,18 +18,21 @@ class RoleSeeder extends Seeder
             [
                 'id' => 1,
                 'name' => 'Admin',
+                'slug' => 'admin',
                 'description' => 'This is the Admin',
             ],
             [
                 'id' => 2,
                 'name' => 'Team Leader',
+                'slug' => 'team-leader',
                 'description' => 'This is the Team Leader',
             ],
             [
                 'id' => 3,
                 'name' => 'User',
+                'slug' => 'user',
                 'description' => 'This is the User',
             ],
-        ], ['id'], ['name', 'description']);
+        ], ['id'], ['name', 'slug', 'description']);
     }
 }

--- a/backend/graphql/role/mutation.graphql
+++ b/backend/graphql/role/mutation.graphql
@@ -5,5 +5,5 @@ extend type Mutation {
         permissions: [ID!]! @rules(apply: ["required", "integer"])
     ): Role!
         @guard(with: ["api"])
-        @hasPermissions(requiredPermission: "Add role")
+        @hasPermissions(requiredPermission: "add-role")
 }

--- a/backend/graphql/role/query.graphql
+++ b/backend/graphql/role/query.graphql
@@ -1,7 +1,19 @@
 extend type Query {
-    role(id: ID @eq): Role @find
-    roles: [Role!]! @all
+    role(slug: String! @eq): Role
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "view-role")
+        @find
+    roles: [Role!]!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "view-role")
+        @all
 
-    permission(id: ID @eq): Permission @find
-    permissions: [Permission!]! @all
+    permission(id: ID @eq): Permission
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "view-role")
+        @find
+    permissions: [Permission!]!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "view-role")
+        @all
 }

--- a/backend/graphql/role/type.graphql
+++ b/backend/graphql/role/type.graphql
@@ -1,6 +1,7 @@
 type Role {
     id: ID!
     name: String!
+    slug: String!
     description: String!
     created_at: String!
     updated_at: String
@@ -10,6 +11,7 @@ type Role {
 type Permission {
     id: ID!
     name: String!
+    slug: String!
     description: String!
     created_at: String!
     updated_at: String


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-78
https://framgiaph.backlog.com/view/SUN_OVERFLOW-79

## Commands
`php artisan migrate:fresh --seed`

```
query getRole {
  role(slug: "team-leader") {
    id
    name
    slug
    description
    permissions {
      id
      name
      slug
    }
  }
}

query getPermissions {
  permissions{
    id
    name
    slug
  }
}
```

## Pre-conditions
Your account should have the `view-role` permission.

## Expected Output

- [ ] Can retrieve role by slug
- [ ] Can retrieve all permissions

## Notes

- Added slug to `roles` and `permissions` migrations
- Updated `hasPermissions` directive and `createRole` mutation to use slug

## Screenshots

_Retrieving role/permissions as a user with **no permission**_
<img width="470" alt="image" src="https://user-images.githubusercontent.com/116238730/225825006-93698dd6-aab3-47bc-ad4d-99e97973bfa2.png">

_Retrieve team leader role_
<img width="468" alt="image" src="https://user-images.githubusercontent.com/116238730/225825160-0a2d352c-b78f-42ff-9884-ad7c61fecc6d.png">

_Retrieve permissions_
<img width="425" alt="image" src="https://user-images.githubusercontent.com/116238730/225825222-ea7f5cdc-fadd-41ec-bbea-f17bf555bf3e.png">
