### PR TITLE
[Overflow-347] [MARKUP] Implement Team Members table

### DIFF
--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -58,7 +58,7 @@ const Table = ({
                                             style={{
                                                 width: column.width,
                                             }}
-                                            className={`py-3 text-center text-sm font-medium uppercase ${
+                                            className={`font-se py-3 text-center text-sm font-semibold uppercase ${
                                                 column.key === 'action' ? 'pl-9' : ''
                                             }`}
                                         >

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -1,9 +1,8 @@
 export type ColumnType = {
     key: string
     title: string
-    width?: number
+    width?: number | string
 }
-
 export type DataType = Record<string, string | number | JSX.Element>
 
 type ClickableType = {
@@ -56,7 +55,9 @@ const Table = ({
                                         <th
                                             key={column.key}
                                             scope="col"
-                                            style={{ width: column.width }}
+                                            style={{
+                                                width: column.width,
+                                            }}
                                             className={`py-3 text-center text-sm font-medium uppercase ${
                                                 column.key === 'action' ? 'pl-9' : ''
                                             }`}

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -125,7 +125,7 @@ const columns: ColumnType[] = [
     {
         title: 'Name',
         key: 'fullName',
-        width: '15%',
+        width: '20%',
     },
     {
         title: 'Team Role',
@@ -135,7 +135,7 @@ const columns: ColumnType[] = [
     {
         title: '',
         key: 'action',
-        width: '15%',
+        width: '10%',
     },
 ]
 

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -1,10 +1,15 @@
+import Icons from '@/components/atoms/Icons'
 import PageStats from '@/components/atoms/PageStats'
+import Paginate from '@/components/organisms/Paginate'
+import type { ColumnType } from '@/components/organisms/Table'
+import Table from '@/components/organisms/Table'
 import GET_TEAM from '@/helpers/graphql/queries/get_team'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { HiPlus } from 'react-icons/hi'
 
 interface UserType {
     id: number
@@ -71,7 +76,7 @@ const TeamDetail = (): JSX.Element => {
                 </div>
             </div>
             <div className="mt-10 flex h-3/5 flex-col">
-                <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
+                <div className="flex h-7 w-[85%] flex-row justify-start border-b-2 border-gray-300">
                     <div
                         className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
                             activeTab === 'Questions'
@@ -89,11 +94,145 @@ const TeamDetail = (): JSX.Element => {
                         Members
                     </div>
                 </div>
-                <div className="flex w-full flex-row justify-center">
-                    <div className="w-full pt-8 text-center text-lg font-medium text-primary-gray">
-                        No {activeTab === 'Questions' ? 'Questions' : 'Members'} to Show
+                <div className="flex w-full">
+                    {activeTab === 'Members' && <MembersTab />}
+                    {activeTab === 'Questions' && (
+                        <div className="w-full pt-8 text-center text-lg font-medium text-primary-gray">
+                            No Questions to Show
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+type MembersQuery = {
+    members: {
+        data: Array<{
+            fullName: string
+            teamRole: string
+        }>
+        paginatorInfo: {
+            currentPage: number
+            hasMorePages: boolean
+            lastPage: number
+        }
+    }
+}
+
+const columns: ColumnType[] = [
+    {
+        title: 'Name',
+        key: 'fullName',
+        width: '15%',
+    },
+    {
+        title: 'Team Role',
+        key: 'teamRole',
+        width: '70%',
+    },
+    {
+        title: '',
+        key: 'action',
+        width: '15%',
+    },
+]
+
+const tempMembers = [
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+    {
+        fullName: 'a',
+        teamRole: 'QA',
+    },
+]
+
+const tempPaginateInfo = {
+    currentPage: 1,
+    hasMorePages: false,
+    lastPage: 1,
+}
+const tempData: MembersQuery = {
+    members: {
+        data: tempMembers,
+        paginatorInfo: tempPaginateInfo,
+    },
+}
+const onPageChange = async (first: number, page: number): Promise<void> => {
+    await new Promise(() => {
+        console.log('ok')
+    })
+}
+const handleDelete = (event: React.MouseEvent<HTMLElement>): void => {
+    console.log('Delete')
+}
+
+const deleteAction = (key: number): JSX.Element => {
+    return (
+        <div onClick={handleDelete}>
+            <Icons name="table_delete" additionalClass="fill-gray-500" />
+        </div>
+    )
+}
+
+const renderMembersActions = (key: number): JSX.Element | undefined => {
+    return <div className="flex flex-row justify-end gap-4 ">{deleteAction(key)}</div>
+}
+
+const MembersTab = (): JSX.Element => {
+    return (
+        <div className="w-full">
+            <div className="  w-[85%] border border-[#555555]">
+                <Table
+                    columns={columns}
+                    dataSource={tempData.members.data}
+                    actions={renderMembersActions}
+                    isEmptyString="No Members to Show"
+                />
+            </div>
+            <div className="relative mt-5 flex w-[85%] ">
+                <div className="mx-auto ">
+                    <div className="ml-32">
+                        <Paginate {...tempData.members.paginatorInfo} onPageChange={onPageChange} />{' '}
                     </div>
                 </div>
+                <button
+                    className="absolute -right-1 top-1/2 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-red-500
+                    "
+                >
+                    <HiPlus color="white" size={50} />
+                </button>
             </div>
         </div>
     )


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-347
## Commands

## Pre-conditions

## Expected Output
* Have a table in Members tab of page `/manage/teams/[slug]`
* Table has Name, Team Role, and actions column
* Name should be a combination of first_name and last_name
* Should only appear when Member's Tab is selected
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/226531191-cf170fdd-8aef-4ba6-a6b7-9ddcf5c821c4.png)

## Affected Pages
`/manage/teams/[slug]`
