### PR TITLE
[Overflow-86] [MARKUP] Create page for viewing of user (Admin)

### DIFF
--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -21,6 +21,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
         '/manage/teams',
         '/manage/roles',
         '/manage/tags',
+        '/manage/users/[slug]',
     ]
 
     const routeIfLoginPathCheck = router.asPath.includes('login')

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -23,10 +23,8 @@ const user: UserType = {
 }
 
 const getActiveTabClass = (status: boolean): string => {
-    if (status) {
-        return '-mb-[1px] hover:text-primary-red px-6 font-semibold border-b-2 border-primary-red bg-red-100'
-    }
-    return '-mb-[1px] hover:text-primary-red px-6 active:border-red-400'
+    return `min-w-[120px] text-center hover:cursor-pointer -mb-[1px] hover:text-primary-red px-6 active:border-red-400 
+    ${status ? 'font-semibold border-b-2 border-primary-red bg-red-100' : ''}`
 }
 
 const UserDetail = (): JSX.Element => {
@@ -62,33 +60,27 @@ const UserDetail = (): JSX.Element => {
                     </div>
                 </div>
                 <div className="mt-8 flex w-full justify-center gap-8 self-start">
-                    <PageStats label="Questions Asked" value={user.question_count}></PageStats>
-                    <PageStats label="Questions Answered" value={user.answer_count}></PageStats>
-                    <PageStats label="Votes Acquired" value={user.vote_count}></PageStats>
+                    <PageStats label="Questions Asked" value={user.question_count} />
+                    <PageStats label="Questions Answered" value={user.answer_count} />
+                    <PageStats label="Votes Acquired" value={user.vote_count} />
                 </div>
             </div>
             <div className="mt-10 flex h-3/5 flex-col">
                 <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
                     <div
-                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
-                            activeTab === 'Questions'
-                        )}`}
+                        className={getActiveTabClass(activeTab === 'Questions')}
                         onClick={onClickQuestionsTab}
                     >
                         Questions
                     </div>
                     <div
-                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
-                            activeTab === 'Answers'
-                        )}`}
+                        className={getActiveTabClass(activeTab === 'Answers')}
                         onClick={onClickAnswersTab}
                     >
                         Answers
                     </div>
                     <div
-                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
-                            activeTab === 'Teams'
-                        )}`}
+                        className={getActiveTabClass(activeTab === 'Teams')}
                         onClick={onClickTeamsTab}
                     >
                         Teams

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -1,0 +1,107 @@
+import PageStats from '@/components/atoms/PageStats'
+import { useState } from 'react'
+import Avatar from 'react-avatar'
+
+interface UserType {
+    id: number
+    first_name: string
+    last_name: string
+    avatar: string
+    question_count: number
+    answer_count: number
+    vote_count: number
+}
+
+const user: UserType = {
+    id: 1,
+    first_name: 'John',
+    last_name: 'Doe',
+    avatar: 'John Doe',
+    question_count: 10,
+    answer_count: 5,
+    vote_count: 20,
+}
+
+const getActiveTabClass = (status: boolean): string => {
+    if (status) {
+        return '-mb-[1px] hover:text-primary-red px-6 font-semibold border-b-2 border-primary-red bg-red-100'
+    }
+    return '-mb-[1px] hover:text-primary-red px-6 active:border-red-400'
+}
+
+const UserDetail = (): JSX.Element => {
+    const [activeTab, setActiveTab] = useState('Questions')
+
+    const onClickQuestionsTab = (): void => {
+        setActiveTab('Questions')
+    }
+
+    const onClickAnswersTab = (): void => {
+        setActiveTab('Answers')
+    }
+
+    const onClickTeamsTab = (): void => {
+        setActiveTab('Teams')
+    }
+
+    return (
+        <div className="mx-10 mt-10 w-full flex-col">
+            <div className="flex">
+                <div className="flex w-full gap-8 p-2">
+                    <Avatar
+                        round={true}
+                        name={`${user.first_name} ${user.last_name}`}
+                        size="120"
+                        alt={user.first_name}
+                        src={user.avatar}
+                        maxInitials={1}
+                        textSizeRatio={2}
+                    />
+                    <div className="w-[90%] self-center truncate text-3xl font-medium">
+                        {`${user.first_name} ${user.last_name}`}
+                    </div>
+                </div>
+                <div className="mt-8 flex w-full justify-center gap-8 self-start">
+                    <PageStats label="Questions Asked" value={user.question_count}></PageStats>
+                    <PageStats label="Questions Answered" value={user.answer_count}></PageStats>
+                    <PageStats label="Votes Acquired" value={user.vote_count}></PageStats>
+                </div>
+            </div>
+            <div className="mt-10 flex h-3/5 flex-col">
+                <div className="flex h-7 w-full flex-row justify-start border-b-2 border-gray-300">
+                    <div
+                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
+                            activeTab === 'Questions'
+                        )}`}
+                        onClick={onClickQuestionsTab}
+                    >
+                        Questions
+                    </div>
+                    <div
+                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
+                            activeTab === 'Answers'
+                        )}`}
+                        onClick={onClickAnswersTab}
+                    >
+                        Answers
+                    </div>
+                    <div
+                        className={`min-w-[120px] text-center hover:cursor-pointer ${getActiveTabClass(
+                            activeTab === 'Teams'
+                        )}`}
+                        onClick={onClickTeamsTab}
+                    >
+                        Teams
+                    </div>
+                </div>
+                <div className="flex w-full flex-row justify-center">
+                    <div className="w-full pt-8 text-center text-lg font-medium text-primary-gray">
+                        No {activeTab} to Show
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default UserDetail


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-86

## Commands
none

## Pre-conditions
none

## Expected Output
`http://localhost:3000/manage/users/slug` will display the user view of the admin. It displays the user's avatar, name, number of questions asked, questions answered and votes acquired as well as the tabs for the user's Questions, Answers and Teams.

## Notes

- Tab content is in a separate task.

## Screenshots
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/116238730/226242262-1627febf-a4cc-4926-a4c0-68924aba17c8.png">
