### PR TITLE
[Overflow-101] [BE] Create API for deleting tags

### DIFF
--- a/backend/app/GraphQL/Mutations/DeleteTag.php
+++ b/backend/app/GraphQL/Mutations/DeleteTag.php
@@ -15,7 +15,7 @@ final class DeleteTag
     {
         $tag = Tag::find($args['id']);
 
-        if(!$tag) {
+        if (!$tag) {
             throw new CustomException('Tag not found!');
         }
 

--- a/backend/app/GraphQL/Mutations/DeleteTag.php
+++ b/backend/app/GraphQL/Mutations/DeleteTag.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\CustomException;
+use App\Models\Tag;
+
+final class DeleteTag
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $tag = Tag::find($args['id']);
+
+        if(!$tag) {
+            throw new CustomException('Tag not found!');
+        }
+
+        $tag->delete();
+
+        return $tag;
+    }
+}

--- a/backend/database/seeders/PermissionSeeder.php
+++ b/backend/database/seeders/PermissionSeeder.php
@@ -154,6 +154,24 @@ class PermissionSeeder extends Seeder
                 'slug' => 'delete-team-role',
                 'description' => 'Can delete own team role',
             ],
+            [
+                'id' => 24,
+                'name' => 'Create tag',
+                'slug' => 'create-tag',
+                'description' => 'Can create a tag',
+            ],
+            [
+                'id' => 25,
+                'name' => 'Update tag',
+                'slug' => 'update-tag',
+                'description' => 'Can update a tag',
+            ],
+            [
+                'id' => 26,
+                'name' => 'Delete tag',
+                'slug' => 'delete-tag',
+                'description' => 'Can delete a tag',
+            ],
         ], ['id'], ['name', 'slug', 'description']);
 
         $admin = Role::find(1);
@@ -161,7 +179,7 @@ class PermissionSeeder extends Seeder
         $user = Role::find(3);
 
         $admin->permissions()->sync(
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
         );
         $teamLead->permissions()->sync([1, 2, 3, 4, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]);
         $user->permissions()->sync([1, 2, 3, 4, 8, 10, 11, 12, 13, 14, 15, 16, 17]);

--- a/backend/graphql/tag/mutation.graphql
+++ b/backend/graphql/tag/mutation.graphql
@@ -1,0 +1,5 @@
+extend type Mutation {
+    deleteTag(id: ID): Tag!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "delete-tag")
+}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-101

## Commands
None

## Pre-conditions
`php artisan db:seed`

## Expected Output
delete api tag

## Notes
Please make sure the table for roles and permission has slug columns, else you need to run `php artisan migrate:fresh --seed` and install passport using `php artisan passport:install` and configure the `.env` file in the backend accordingly

## Screenshots

- with admin permission
![image](https://user-images.githubusercontent.com/114911074/226254380-32cb2f65-9830-4478-9c27-7bf60312abe3.png)
- without admin permission
![image](https://user-images.githubusercontent.com/114911074/226254448-7b175b1b-2e55-41ec-9132-c4d2313567f5.png)
