### PR TITLE
[Overflow-84] [MARKUP] Create page for users (Admin)

### DIFF
--- a/frontend/components/organisms/Sidebar/LeftSideBar.tsx
+++ b/frontend/components/organisms/Sidebar/LeftSideBar.tsx
@@ -42,6 +42,11 @@ const LeftSideBar = (): JSX.Element => {
                     Text: 'Roles',
                     url: 'manage/roles',
                 },
+                {
+                    IconName: 'Users',
+                    Text: 'Users',
+                    url: 'manage/users',
+                },
             ],
         },
     ]

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -57,7 +57,7 @@ const Table = ({
                                             key={column.key}
                                             scope="col"
                                             style={{ width: column.width }}
-                                            className={`py-3 pl-16 pr-6 text-center text-sm font-medium uppercase ${
+                                            className={`py-3 text-center text-sm font-medium uppercase ${
                                                 column.key === 'action' ? 'pl-9' : ''
                                             }`}
                                         >

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -88,7 +88,7 @@ const Table = ({
                                                     return (
                                                         <td
                                                             key={key}
-                                                            className="min-w-[300px] whitespace-nowrap py-4 text-center text-sm"
+                                                            className="min-w-[200px] whitespace-nowrap py-4 text-center text-sm"
                                                         >
                                                             {clickable !== undefined
                                                                 ? renderClickable(

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -21,6 +21,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
         '/manage/teams',
         '/manage/roles',
         '/manage/tags',
+        '/manage/users',
         '/manage/users/[slug]',
     ]
 

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -1,0 +1,118 @@
+import Icons from '@/components/atoms/Icons'
+import Paginate from '@/components/organisms/Paginate'
+import type { ColumnType } from '@/components/organisms/Table'
+import Table from '@/components/organisms/Table'
+import { useRouter } from 'next/router'
+
+const columns: ColumnType[] = [
+    {
+        title: 'Name',
+        key: 'name',
+    },
+    {
+        title: 'Questions Posted',
+        key: 'question_count',
+    },
+    {
+        title: 'Answers Posted',
+        key: 'answer_count',
+    },
+    {
+        title: 'Role',
+        key: 'role',
+    },
+    {
+        title: '',
+        key: 'action',
+        width: 20,
+    },
+]
+
+const tempValues = [
+    {
+        id: 1,
+        name: 'John Doe',
+        slug: 'john-doe',
+        question_count: 5,
+        answer_count: 6,
+        role: 'Admin',
+    },
+    {
+        id: 2,
+        name: 'Jane Doe',
+        slug: 'jane-doe',
+        question_count: 5,
+        answer_count: 6,
+        role: 'Admin',
+    },
+    {
+        id: 3,
+        name: 'John Smith',
+        slug: 'john-smith',
+        question_count: 5,
+        answer_count: 6,
+        role: 'Admin',
+    },
+    {
+        id: 4,
+        name: 'Jane Roe',
+        slug: 'jane-roe',
+        question_count: 5,
+        answer_count: 6,
+        role: 'Admin',
+    },
+]
+
+const tempPaginateProps = {
+    currentPage: 1,
+    lastPage: 2,
+    hasMorePages: true,
+    onPageChange: () => {
+        console.log('next')
+    },
+}
+
+const editAction = (): JSX.Element => {
+    return (
+        <div>
+            <Icons name="table_edit" additionalClass="fill-gray-500" />
+        </div>
+    )
+}
+
+const AdminUsers = (): JSX.Element => {
+    const router = useRouter()
+
+    const clickableArr = [
+        {
+            column: 'name',
+            onClick: (slug: string): void => {
+                void router.push({
+                    pathname: '/manage/users/[slug]',
+                    query: { slug },
+                })
+            },
+        },
+    ]
+
+    return (
+        <div className="flex w-full flex-col gap-4 p-8">
+            <div className="flex h-full flex-col gap-4">
+                <div className="mt-4 flex items-center">
+                    <h1 className="text-3xl font-bold">Users</h1>
+                </div>
+                <div className="overflow-hidden border border-secondary-black">
+                    <Table
+                        columns={columns}
+                        dataSource={tempValues}
+                        actions={editAction}
+                        clickableArr={clickableArr}
+                    />
+                </div>
+                <Paginate {...tempPaginateProps} />
+            </div>
+        </div>
+    )
+}
+
+export default AdminUsers


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-84

## Commands
none

## Pre-conditions
none

## Expected Output
`http://localhost:3000/manage/users` will show a tabulated list of users.
Clicking on the name will redirect to the user detail page for admins.

## Notes
Removed the view icon button, and replaced it with a clickable name column.

## Screenshots
<img width="959" alt="image" src="https://user-images.githubusercontent.com/116238730/226282038-b9b10ddf-53b2-46d4-9753-53caf9bc346a.png">
