### PR TITLE
[Overflow-107] [BE] Create API for storing teams

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateTeam.php
+++ b/backend/app/GraphQL/Mutations/CreateTeam.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\CustomException;
+use App\Models\Team;
+use App\Models\User;
+use Exception;
+use Illuminate\Support\Str;
+
+final class CreateTeam
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        try {
+            $user = User::findOrFail($args['user_id']);
+
+            $team = Team::create([
+                'name' => $args['name'],
+                'description' => $args['description'],
+                'user_id' => $user->id,
+            ]);
+
+            return $team;
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+            if (Str::contains($message, 'No query results for model')) {
+                return new CustomException('Invalid user ID.');
+            } else {
+                return new CustomException('An error has occured.');
+            }
+        }
+    }
+}

--- a/backend/app/GraphQL/Mutations/DeleteTeam.php
+++ b/backend/app/GraphQL/Mutations/DeleteTeam.php
@@ -2,7 +2,6 @@
 
 namespace App\GraphQL\Mutations;
 
-use App\Exceptions\CustomException;
 use App\Models\Team;
 
 final class DeleteTeam
@@ -14,10 +13,6 @@ final class DeleteTeam
     public function __invoke($_, array $args)
     {
         $team = Team::find($args['id']);
-
-        if (auth()->user()->role->name != 'Admin') {
-            throw new CustomException('You are not allowed to remove Team');
-        }
 
         $team->delete();
 

--- a/backend/database/migrations/2023_01_26_040851_create_teams_table.php
+++ b/backend/database/migrations/2023_01_26_040851_create_teams_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('description');
-            $table->mediumText('dashboard_content');
+            $table->mediumText('dashboard_content')->nullable();
             $table->foreignId('user_id')->constrained();
             $table->timestamps();
             $table->softDeletes();

--- a/backend/graphql/team/mutation.graphql
+++ b/backend/graphql/team/mutation.graphql
@@ -1,9 +1,18 @@
 extend type Mutation {
+    createTeam(
+        name: String! @rules(apply: ["required"])
+        description: String! @rules(apply: ["required"])
+        user_id: ID! @rules(apply: ["required", "integer"])
+    ): Team!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "add-team")
     updateTeamDashboard(
         id: ID! @rules(apply: ["required", "integer"])
         dashboard_content: String! @rules(apply: ["required"])
     ): Team! @guard(with: ["api"])
     deleteTeam(id: ID!): Team!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "delete-team")
     # Please add this to your code on update team if the team leader is new then add the new team leader as a member
     # $team->members()->create([
     #     "user_id" => $team->user_id,


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-107

## Commands
Run `php artisan migrate:fresh --seed` to apply Team migration updates.

## Pre-conditions
You must be an admin to create a team.

## Expected Output

- [x] Admin users can create a team.

## Notes

- Update `deleteTeam` mutation to use `hasPermissions` directive

## Screenshots
_Successful team creation_
<img width="512" alt="image" src="https://user-images.githubusercontent.com/116238730/226569278-86a93e91-3144-4dd1-b3ac-dc2b6dea8c8d.png">

_Passing an invalid user ID_
<img width="487" alt="image" src="https://user-images.githubusercontent.com/116238730/226570181-634a59a8-4757-4074-aeb1-41b086b00d87.png">

