### PR TITLE
[Overflow-110] [BE] Create API for updating teams

### DIFF
--- a/backend/app/GraphQL/Mutations/UpdateTeam.php
+++ b/backend/app/GraphQL/Mutations/UpdateTeam.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\CustomException;
+use App\Models\Team;
+use App\Models\User;
+use Exception;
+use Illuminate\Support\Str;
+
+final class UpdateTeam
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        try {
+            $team = Team::findOrFail($args['id']);
+
+            $teamLeader = $team->user_id;
+
+            $team->name = $args['name'];
+            $team->description = $args['description'];
+            $team->user_id = $args['user_id'];
+
+            if ($team->isDirty('user_id')) {
+                if (User::where('id', $team->user_id)->exists() && User::find($team->user_id)->role_id == 2) {
+                    $team->members()->where('user_id', $teamLeader)->delete();
+
+                    $team->members()->create([
+                        'user_id' => $team->user_id,
+                        'team_id' => $team->id,
+                    ]);
+                } else {
+                    return new CustomException('Invalid user ID.');
+                }
+            }
+
+            if ($team->isClean()) {
+                return new CustomException('No values to update.');
+            }
+
+            $team->save();
+
+            return $team;
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+            if (Str::contains($message, 'No query results for model')) {
+                return new CustomException('Invalid team ID.');
+            } else {
+                return new CustomException('An error has occured.');
+            }
+        }
+    }
+}

--- a/backend/graphql/team/mutation.graphql
+++ b/backend/graphql/team/mutation.graphql
@@ -6,6 +6,14 @@ extend type Mutation {
     ): Team!
         @guard(with: ["api"])
         @hasPermissions(requiredPermission: "add-team")
+    updateTeam(
+        id: ID! @rules(apply: ["required", "integer"])
+        name: String!
+        description: String!
+        user_id: ID! @rules(apply: ["integer"])
+    ): Team!
+        @guard(with: ["api"])
+        @hasPermissions(requiredPermission: "edit-team")
     updateTeamDashboard(
         id: ID! @rules(apply: ["required", "integer"])
         dashboard_content: String! @rules(apply: ["required"])
@@ -13,9 +21,4 @@ extend type Mutation {
     deleteTeam(id: ID!): Team!
         @guard(with: ["api"])
         @hasPermissions(requiredPermission: "delete-team")
-    # Please add this to your code on update team if the team leader is new then add the new team leader as a member
-    # $team->members()->create([
-    #     "user_id" => $team->user_id,
-    #     "team_id" => $team->id,
-    # ]);
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-110

## Commands
none

## Pre-conditions
You must be an admin to update a team.

## Expected Output

- [x] Admin users can update a team's name, description and team leader (only users with the team leader role can be assigned).

## Notes

## Screenshots
_Successful update_
<img width="487" alt="image" src="https://user-images.githubusercontent.com/116238730/226791591-ba35d0b0-2f4d-4a2d-ac34-3c8a9beca828.png">

_Passing the same values_
<img width="496" alt="image" src="https://user-images.githubusercontent.com/116238730/226791478-379123de-5df3-48d2-98af-83275b16333f.png">

_Passing a team ID that does not exist_
<img width="467" alt="image" src="https://user-images.githubusercontent.com/116238730/226791520-151a775b-9848-4627-929a-d287300ea1d2.png">

_Passing a user ID that does not exist_
<img width="467" alt="image" src="https://user-images.githubusercontent.com/116238730/226791279-e5bb4c1e-2b9b-4bc7-9a57-8e0f2a495d24.png">

_Passing a user ID that is not a team leader_
<img width="179" alt="image" src="https://user-images.githubusercontent.com/116238730/226791338-4cb10cf2-f69f-44c8-bca3-0e4076289775.png">
<img width="447" alt="image" src="https://user-images.githubusercontent.com/116238730/226791418-a44db06c-7bcc-4a66-94db-d5d8047a2194.png">