### PR TITLE
[Overflow-325] [FE] Implement Delete Tag API to page

### DIFF
--- a/frontend/components/organisms/TagsAction/index.tsx
+++ b/frontend/components/organisms/TagsAction/index.tsx
@@ -1,6 +1,9 @@
 import Button from '@/components/atoms/Button'
 import Icons from '@/components/atoms/Icons'
 import Modal from '@/components/templates/Modal'
+import DELETE_TAG from '@/helpers/graphql/mutations/delete_tag'
+import { errorNotify, successNotify } from '@/helpers/toast'
+import { useMutation } from '@apollo/client'
 import { useState } from 'react'
 import TagsFormModal from '../TagsFormModal'
 
@@ -11,9 +14,56 @@ type Props = {
     refetchHandler: () => void
 }
 
+const renderDeleteAction = (id: number, name: string, refetch: () => void): JSX.Element => {
+    const [showDeleteModal, setShowDeleteModal] = useState(false)
+    const [deleteTag] = useMutation(DELETE_TAG)
+
+    const closeDeleteModal = (): void => {
+        setShowDeleteModal(false)
+    }
+
+    const handleSubmit = (): void => {
+        deleteTag({ variables: { id } })
+            .then(() => {
+                successNotify('Tag deleted.')
+                refetch()
+            })
+            .catch(() => {
+                errorNotify('Failed to delete tag.')
+            })
+            .finally(() => {
+                setShowDeleteModal(false)
+            })
+    }
+
+    return (
+        <>
+            <Button
+                usage="toggle-modal"
+                onClick={(): void => {
+                    setShowDeleteModal(true)
+                }}
+            >
+                <Icons name="table_delete" additionalClass="fill-gray-500" />
+            </Button>
+            <Modal
+                title="Delete Tag"
+                isOpen={showDeleteModal}
+                handleClose={closeDeleteModal}
+                handleSubmit={handleSubmit}
+                submitLabel="Delete"
+            >
+                <span>
+                    Are you sure you wish to delete the <span className="font-bold">{name}</span>{' '}
+                    tag?
+                </span>
+            </Modal>
+        </>
+    )
+}
+
 const TagsActions = ({ id, name, description, refetchHandler }: Props): JSX.Element => {
     const [showEditModal, setShowEditModal] = useState(false)
-    const [showDeleteModal, setShowDeleteModal] = useState(false)
 
     const initialData = {
         id,
@@ -23,10 +73,6 @@ const TagsActions = ({ id, name, description, refetchHandler }: Props): JSX.Elem
 
     const closeEditModal = (): void => {
         setShowEditModal(false)
-    }
-
-    const closeDeleteModal = (): void => {
-        setShowDeleteModal(false)
     }
 
     return (
@@ -39,32 +85,13 @@ const TagsActions = ({ id, name, description, refetchHandler }: Props): JSX.Elem
             >
                 <Icons name="table_edit" additionalClass="fill-gray-500" />
             </Button>
-            <Button
-                usage="toggle-modal"
-                onClick={(): void => {
-                    setShowDeleteModal(true)
-                }}
-            >
-                <Icons name="table_delete" additionalClass="fill-gray-500" />
-            </Button>
             <TagsFormModal
                 isOpen={showEditModal}
                 closeModal={closeEditModal}
                 refetchHandler={refetchHandler}
                 initialData={initialData}
             />
-            <Modal
-                title="Delete Tag"
-                isOpen={showDeleteModal}
-                handleClose={closeDeleteModal}
-                handleSubmit={closeDeleteModal}
-                submitLabel="Delete"
-            >
-                <span>
-                    Are you sure you wish to delete the{' '}
-                    <span className="font-bold">JavaScript</span> tag?
-                </span>
-            </Modal>
+            {renderDeleteAction(id, name, refetchHandler)}
         </div>
     )
 }

--- a/frontend/components/organisms/TagsAction/index.tsx
+++ b/frontend/components/organisms/TagsAction/index.tsx
@@ -53,10 +53,10 @@ const renderDeleteAction = (id: number, name: string, refetch: () => void): JSX.
                 handleSubmit={handleSubmit}
                 submitLabel="Delete"
             >
-                <span>
-                    Are you sure you wish to delete the <span className="font-bold">{name}</span>{' '}
-                    tag?
-                </span>
+                <div className="flex flex-wrap gap-1">
+                    Are you sure you wish to delete the{' '}
+                    <div className="truncate font-bold">{name}</div> tag?
+                </div>
             </Modal>
         </>
     )

--- a/frontend/helpers/graphql/mutations/delete_tag.ts
+++ b/frontend/helpers/graphql/mutations/delete_tag.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client'
+
+const DELETE_TAG = gql`
+    mutation DeleteTag($id: ID!) {
+        deleteTag(id: $id) {
+            id
+            name
+            slug
+        }
+    }
+`
+export default DELETE_TAG

--- a/frontend/pages/manage/tags/index.tsx
+++ b/frontend/pages/manage/tags/index.tsx
@@ -63,6 +63,7 @@ const Tags: NextPage = () => {
     const onPageChange = async (first: number, page: number): Promise<void> => {
         await refetch({ first, page })
     }
+
     const renderPagination = (): JSX.Element => {
         return pageInfo.lastPage > 1 ? (
             <Paginate {...pageInfo} perPage={6} onPageChange={onPageChange} />
@@ -78,11 +79,12 @@ const Tags: NextPage = () => {
     const refetchHandler = (): void => {
         void refetch({
             first: 6,
-            page: 1,
+            page: pageInfo.currentPage,
             name: '%%',
             sort: [{ column: 'POPULARITY', order: 'DESC' }],
         })
     }
+
     const getTagsDataTable = (tagList: DataType[]): DataType[] => {
         return tagList.map((tag): DataType => {
             return {


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-325

## Commands
none

## Pre-conditions
You must be an admin user to delete a tag.

## Expected Output

- [x] Clicking on the delete icon in the Tags table will show the delete confirmation modal.

## Notes
none

## Screenshots
<img width="476" alt="image" src="https://user-images.githubusercontent.com/116238730/227125186-c54d69cb-0bd5-4f43-b450-a5de4ddecc68.png">
<img width="479" alt="image" src="https://user-images.githubusercontent.com/116238730/227125269-7b3150b6-df2e-489a-a51f-385d532377ee.png">

