### PR TITLE
[OVERFLOW-372] [BUGFIX] Truncate data in table tags

### DIFF
--- a/backend/app/Models/Tag.php
+++ b/backend/app/Models/Tag.php
@@ -62,15 +62,11 @@ class Tag extends Model
 
     public function getTruncatedNameAttribute()
     {
-        $name = $this->name;
-
-        return Str::limit($name, 15, '...');
+        return Str::limit($this->name, 15, '...');
     }
 
     public function getTruncatedDescriptionAttribute()
     {
-        $description = $this->description;
-
-        return Str::limit($description, 50, '...');
+        return Str::limit($this->description, 50, '...');
     }
 }

--- a/backend/app/Models/Tag.php
+++ b/backend/app/Models/Tag.php
@@ -13,7 +13,10 @@ class Tag extends Model
 
     protected $guarded = [];
 
-    protected $appends = ['is_watched_by_user', 'count_tagged_questions', 'count_watching_users'];
+    protected $appends = [
+        'is_watched_by_user', 'count_tagged_questions', 'count_watching_users',
+        'truncated_name', 'truncated_description',
+    ];
 
     protected static function boot()
     {
@@ -55,5 +58,19 @@ class Tag extends Model
     public function getCountWatchingUsersAttribute()
     {
         return $this->belongsToMany(User::class)->count();
+    }
+
+    public function getTruncatedNameAttribute()
+    {
+        $name = $this->name;
+
+        return Str::limit($name, 15, '...');
+    }
+
+    public function getTruncatedDescriptionAttribute()
+    {
+        $description = $this->description;
+
+        return Str::limit($description, 50, '...');
     }
 }

--- a/backend/graphql/tag/query.graphql
+++ b/backend/graphql/tag/query.graphql
@@ -10,7 +10,7 @@ extend type Query {
     ): [Tag!]
         @guard(with: ["api"])
         @paginate(builder: "App\\GraphQL\\Queries\\Tags")
-    tag(slug: String! @eq): Tag @guard(with: ["api"]) @find
+    tag(slug: String! @eq): Tag @find
     tagSuggest(name: String! = "%%" @where(operator: "like")): [Tag]
         @guard(with: ["api"])
         @all

--- a/backend/graphql/tag/type.graphql
+++ b/backend/graphql/tag/type.graphql
@@ -9,4 +9,6 @@ type Tag {
     usersWatching: [User!]! @belongsToMany
     count_tagged_questions: Int!
     count_watching_users: Int!
+    truncated_name: String!
+    truncated_description: String!
 }

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -91,17 +91,13 @@ const Table = ({
                                                             key={key}
                                                             className="min-w-[200px] whitespace-nowrap py-4 text-center text-sm"
                                                         >
-                                                            {clickable !== undefined ? (
-                                                                renderClickable(
-                                                                    data[column.key],
-                                                                    clickable,
-                                                                    data.slug as string
-                                                                )
-                                                            ) : (
-                                                                <p className="max-w-[50ch] truncate px-6">
-                                                                    {data[column.key]}
-                                                                </p>
-                                                            )}
+                                                            {clickable !== undefined
+                                                                ? renderClickable(
+                                                                      data[column.key],
+                                                                      clickable,
+                                                                      data.slug as string
+                                                                  )
+                                                                : data[column.key]}
                                                         </td>
                                                     )
                                                 })}

--- a/frontend/helpers/graphql/queries/get_tags.ts
+++ b/frontend/helpers/graphql/queries/get_tags.ts
@@ -17,6 +17,8 @@ const GET_TAGS = gql`
                 is_watched_by_user
                 count_tagged_questions
                 count_watching_users
+                truncated_name
+                truncated_description
             }
         }
     }

--- a/frontend/pages/manage/tags/index.tsx
+++ b/frontend/pages/manage/tags/index.tsx
@@ -87,8 +87,8 @@ const Tags: NextPage = () => {
         return tagList.map((tag): DataType => {
             return {
                 key: tag.id,
-                name: tag.name,
-                description: tag.description,
+                name: tag.truncated_name,
+                description: tag.truncated_description,
                 count_tagged_questions: tag.count_tagged_questions,
                 slug: tag.slug,
             }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-372

## Commands
None

## Pre-conditions
None

## Expected Output
- The name and description in tags admin are truncated

## Notes
None

## Screenshots

![image](https://user-images.githubusercontent.com/112840596/227152767-ff749d08-9ddb-47b2-bff9-dec4bd0cd9d1.png)

