### PR TITLE
[Overflow-373] [BUGFIX] Tag Tooltip

### DIFF
--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -44,7 +44,7 @@ const getButtonClasses = (usage: string): string => {
         case 'icon':
             return 'absolute inset-y-0 right-0 mr-2 flex items-center'
         case 'popover':
-            return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 bg-white border-red-500 focus:ring-red-600 hover:bg-rose-200'
+            return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 bg-white border-red-500 focus:ring-red-600 hover:bg-light-red'
         case 'cancel-item':
             return 'items-center rounded-full border-2 outline-0 border-primary-red absolute outline-primary-red -top-2 -right-2 bg-white text-primary-red p-1 hover:bg-primary-red hover:text-white active:bg-primary-red active:text-white active:outline active:outline-[2px]'
         case 'edit-top-right':

--- a/frontend/components/molecules/Pill/index.tsx
+++ b/frontend/components/molecules/Pill/index.tsx
@@ -1,10 +1,8 @@
 import Icons from '@/components/atoms/Icons'
 import { useBoundStore } from '@/helpers/store'
-import { Float } from '@headlessui-float/react'
-import { Popover } from '@headlessui/react'
-import { useState } from 'react'
-import { usePopper } from 'react-popper'
+import { Popover, PopoverContent, PopoverHandler } from '@material-tailwind/react'
 import Tooltips from '../Tooltip'
+
 type PillProps = {
     tag: {
         id: number
@@ -18,41 +16,27 @@ type PillProps = {
 }
 
 const Pill = ({ tag }: PillProps): JSX.Element => {
-    const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>()
-    const [popperElement, setPopperElement] = useState<HTMLDivElement | null>()
-    const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>()
-    const { styles, attributes } = usePopper(referenceElement, popperElement, {
-        modifiers: [{ name: 'arrow', options: { element: arrowElement } }],
-    })
-
     const watchedTags = useBoundStore((state) => state.watchedTags)
 
     return (
-        <Popover>
-            <Float placement="bottom-start" offset={5} arrow>
-                <Popover.Button type="button" className="!outline-none">
-                    <div
-                        className="flex min-w-fit flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal !outline-none"
-                        ref={setReferenceElement}
-                    >
-                        {watchedTags.some((tempTag) => tempTag.name === tag.name) && (
-                            <Icons name="pill_eye" />
-                        )}
-                        <span>{tag.name}</span>
-                    </div>
-                </Popover.Button>
-                <Popover.Panel
-                    className="bg-zinc-200 absolute z-10 mt-3 w-96 rounded-lg shadow-lg"
-                    ref={setPopperElement}
-                    style={styles.popper}
-                    {...attributes.popper}
-                >
-                    <div ref={setArrowElement} style={styles.arrow}>
-                        <Float.Arrow className="bg-zinc-200 relative ml-3 h-6 w-6 rotate-45" />
-                    </div>
-                    <Tooltips tag={tag} />
-                </Popover.Panel>
-            </Float>
+        <Popover
+            placement="bottom-start"
+            animate={{
+                mount: { scale: 1, y: 0 },
+                unmount: { scale: 0, y: 25 },
+            }}
+        >
+            <PopoverHandler>
+                <div className="flex min-w-fit cursor-pointer flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal !outline-none">
+                    {watchedTags.some((tempTag) => tempTag.name === tag.name) && (
+                        <Icons name="pill_eye" />
+                    )}
+                    <span>{tag.name}</span>
+                </div>
+            </PopoverHandler>
+            <PopoverContent className="max-w-[22rem] bg-gray-200">
+                <Tooltips tag={tag} />
+            </PopoverContent>
         </Popover>
     )
 }

--- a/frontend/components/molecules/Tooltip/index.tsx
+++ b/frontend/components/molecules/Tooltip/index.tsx
@@ -50,13 +50,19 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
     }
 
     return (
-        <div className="p-5 font-normal">
+        <div className="cursor-default font-normal">
             <div className="flex items-center">
-                <p className="mr-20 text-red-700">{tag.count_watching_users} Watchers</p>
-                <p className="mr-2">{tag.count_tagged_questions} Questions</p>
+                <span className="mr-20 text-red-700">
+                    {tag.count_watching_users}{' '}
+                    {(tag.count_watching_users as number) !== 1 ? `Watchers` : `Watcher`}
+                </span>
+                <span className="mr-2">
+                    {tag.count_tagged_questions}{' '}
+                    {(tag.count_tagged_questions as number) !== 1 ? `Questions` : `Question`}
+                </span>
             </div>
-            <div className=" cursor-pointer py-2">
-                <p>
+            <div className="py-2">
+                <span>
                     {tag.description}
                     <Link
                         href={`/questions/tagged/${tag.slug ?? ''}`}
@@ -64,9 +70,9 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
                     >
                         View Tag
                     </Link>
-                </p>
+                </span>
             </div>
-            <div className="float-right ml-2 mb-2 p-2">
+            <div className="float-right p-2">
                 <Button
                     usage="popover"
                     type="submit"

--- a/frontend/pages/questions/tagged/[slug].tsx
+++ b/frontend/pages/questions/tagged/[slug].tsx
@@ -1,21 +1,21 @@
-import { useQuery } from '@apollo/client'
-import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
-import { errorNotify } from '../../../helpers/toast'
-import { loadingScreenShow } from '../../../helpers/loaderSpinnerHelper'
-import { useRouter } from 'next/router'
-import type { RefetchType } from '../index'
-import { useEffect, useState } from 'react'
 import QuestionsPageLayout from '@/components/templates/QuestionsPageLayout'
+import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
+import { useQuery } from '@apollo/client'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { loadingScreenShow } from '../../../helpers/loaderSpinnerHelper'
+import { errorNotify } from '../../../helpers/toast'
+import type { RefetchType } from '../index'
 
 const TagsPage = (): JSX.Element => {
     const router = useRouter()
-    const [selectedTag, setSelectedTag] = useState('')
+    const [selectedTag, setSelectedTag] = useState(router.query.slug as string)
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTIONS, {
         variables: {
             first: 10,
             page: 1,
             orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-            filter: { answered: true, tag: selectedTag },
+            filter: { tag: selectedTag },
         },
     })
 
@@ -26,7 +26,7 @@ const TagsPage = (): JSX.Element => {
             first: 10,
             page: 1,
             orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-            filter: { answered: true, tag: selectedTag },
+            filter: { tag: selectedTag },
         })
         setSelectedTag(slug as string)
     }, [router, selectedTag, refetch])


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-373

## Commands
none

## Pre-conditions
none

## Expected Output

- [x] Clicking on `View Tag` in the tag tooltip redirects to `/questions/tagged/javascript` and displays all questions associated with the tag.

## Notes
The tooltip may look different since it has been replaced with Material Tailwind Popover component.

## Screenshots
<img width="516" alt="image" src="https://user-images.githubusercontent.com/116238730/227163586-3e0502c1-cb63-46e4-8d89-4a8b41a65587.png">
<img width="535" alt="image" src="https://user-images.githubusercontent.com/116238730/227163637-515fbd70-b045-4d58-9bcb-148092b13421.png">
