### PR TITLE
[Overflow-92] [FE] Implement API to Admin Users Page List and Details

### DIFF
--- a/frontend/helpers/graphql/mutations/assign_role.ts
+++ b/frontend/helpers/graphql/mutations/assign_role.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client'
+
+const ASSIGN_ROLE = gql`
+    mutation AssignRole($userId: ID!, $roleId: ID!) {
+        assignRole(user_id: $userId, role_id: $roleId) {
+            id
+            role {
+                id
+                name
+            }
+        }
+    }
+`
+export default ASSIGN_ROLE

--- a/frontend/helpers/graphql/queries/get_role_selection.ts
+++ b/frontend/helpers/graphql/queries/get_role_selection.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client'
+
+const GET_ROLES_SELECTION = gql`
+    query Roles {
+        roles {
+            id
+            name
+        }
+    }
+`
+
+export default GET_ROLES_SELECTION

--- a/frontend/helpers/graphql/queries/get_users_admin.ts
+++ b/frontend/helpers/graphql/queries/get_users_admin.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client'
+
+const GET_USERS_ADMIN = gql`
+    query UsersAdmin($first: Int!, $page: Int!, $filter: userFilter, $sort: userSort) {
+        users(first: $first, page: $page, filter: $filter, sort: $sort) {
+            paginatorInfo {
+                perPage
+                currentPage
+                lastPage
+                hasMorePages
+                total
+            }
+            data {
+                id
+                first_name
+                last_name
+                question_count
+                answer_count
+                role {
+                    name
+                }
+                slug
+            }
+        }
+    }
+`
+
+export default GET_USERS_ADMIN

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -37,9 +37,6 @@ const UserDetail = (): JSX.Element => {
     const [activeTab, setActiveTab] = useState('Questions')
     const userQuery = useQuery<{ user: UserType }>(GET_USER, {
         variables: { slug: router.query.slug },
-        onCompleted: (e) => {
-            console.log(e)
-        },
     })
     const onClickQuestionsTab = (): void => {
         setActiveTab('Questions')

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -167,6 +167,7 @@ const AdminUsers = (): JSX.Element => {
     const onSubmit = async (data: FormValues): Promise<void> => {
         if (!isDirty) {
             errorNotify(`Error: No changes were made`)
+            closeEdit()
             return
         }
         closeEdit()

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -101,7 +101,13 @@ const AdminUsers = (): JSX.Element => {
     const rolesQuery = useQuery(GET_ROLES_SELECTION)
     const [assignRole] = useMutation(ASSIGN_ROLE)
     const roles = rolesQuery?.data?.roles ?? []
-    const { control, handleSubmit, setValue } = useForm<FormValues>({
+    const {
+        control,
+        handleSubmit,
+        setValue,
+        reset,
+        formState: { isDirty },
+    } = useForm<FormValues>({
         defaultValues: {
             userId: 0,
             role: 1,
@@ -143,8 +149,10 @@ const AdminUsers = (): JSX.Element => {
                 usage="toggle-modal"
                 onClick={() => {
                     setIsOpenEdit(true)
-                    setValue('role', convertRoleStrToInt(roles, newUserArr[key].role))
-                    setValue('userId', newUserArr[key].id)
+                    reset({
+                        role: convertRoleStrToInt(roles, newUserArr[key].role),
+                        userId: newUserArr[key].id,
+                    })
                 }}
             >
                 <Icons name="table_edit" additionalClass="fill-gray-500" />
@@ -157,6 +165,10 @@ const AdminUsers = (): JSX.Element => {
     }
 
     const onSubmit = async (data: FormValues): Promise<void> => {
+        if (!isDirty) {
+            errorNotify(`Error: No changes were made`)
+            return
+        }
         closeEdit()
         await assignRole({ variables: { userId: data.userId, roleId: data.role } })
             .then((data) => {

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -157,7 +157,6 @@ const AdminUsers = (): JSX.Element => {
     }
 
     const onSubmit = async (data: FormValues): Promise<void> => {
-        console.log(data)
         closeEdit()
         await assignRole({ variables: { userId: data.userId, roleId: data.role } })
             .then((data) => {


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-92

## Commands

## Pre-conditions

## Expected Output
- Working Edit Button in `/manage/users`
- Working redirect to `/manage/users/[slug]` by clicking the name
- Proper data displayed in the top part of `/manage/users/[slug]`
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/227420793-1d0b08cc-be5c-4eff-b5b1-63703b4c1a28.png)
![image](https://user-images.githubusercontent.com/114897466/227420812-01f6eeaf-c089-484a-9be9-aaa8a037d906.png)
![image](https://user-images.githubusercontent.com/114897466/227420830-5511acb4-b47d-42ac-b41f-ef9d58478478.png)
![image](https://user-images.githubusercontent.com/114897466/227420852-434555f9-3481-4ccc-bc40-9d80261f0374.png)
