### PR TITLE
[Overflow-378] [Bugfix] Change Validation Message for Accepting Answer

### DIFF
--- a/backend/app/Observers/AnswerObserver.php
+++ b/backend/app/Observers/AnswerObserver.php
@@ -5,6 +5,7 @@ namespace App\Observers;
 use App\Events\NotificationEvent;
 use App\Models\Answer;
 use App\Models\UserNotification;
+use Illuminate\Support\Facades\Auth;
 
 class AnswerObserver
 {
@@ -30,14 +31,15 @@ class AnswerObserver
     public function updated(Answer $answer)
     {
         if ($answer->is_correct) {
-            if (auth()->id != $answer->user_id) {
+            if (Auth::id() != $answer->user_id) {
                 UserNotification::create([
                     'user_id' => $answer->user_id,
                     'notifiable_type' => 'App\Models\Answer',
                     'notifiable_id' => $answer->id,
                 ]);
-
-                event(new NotificationEvent($answer->user_id));
+                if (env('NOTIFY_USERS')) {
+                    event(new NotificationEvent($answer->user_id));
+                }
             }
         }
     }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-378
## Commands

## Pre-conditions

## Expected Output
* Instead of an error message the Toast outputs "Answer was accepted successfully"
## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/227853486-8c3a3e9a-32cc-407d-9e31-762e383be813.png)
