### PR TITLE
[Overflow-386] [BUGFIX] Redirect after deleting tag

### DIFF
--- a/frontend/components/organisms/RoleForm/index.tsx
+++ b/frontend/components/organisms/RoleForm/index.tsx
@@ -109,12 +109,17 @@ const RoleForm = ({ role }: Props): JSX.Element => {
 
         if (valid) {
             if (role) {
-                const matchPermissions = selectedPermissions.map((permission) =>
-                    permissionsForm.includes(permission)
-                )
+                const matchPermissions: number[] = []
+
+                permissionsForm.forEach((permission) => {
+                    if (selectedPermissions.includes(permission)) {
+                        matchPermissions.push(permission)
+                    }
+                })
 
                 if (
                     matchPermissions.length === permissionsForm.length &&
+                    matchPermissions.length === selectedPermissions.length &&
                     role?.name === data.name &&
                     role?.description === data.description
                 ) {
@@ -129,9 +134,11 @@ const RoleForm = ({ role }: Props): JSX.Element => {
                             permissions: permissionsForm,
                         },
                     })
-                        .then(async () => {
+                        .then(() => {
                             successNotify('Successfully updated role!')
-                            void router.push('/manage/roles')
+                            setTimeout(() => {
+                                void router.push('/manage/roles')
+                            }, 1)
                         })
                         .catch(() => {
                             errorNotify('There was an Error!')
@@ -145,9 +152,11 @@ const RoleForm = ({ role }: Props): JSX.Element => {
                         permissions: permissionsForm,
                     },
                 })
-                    .then(async () => {
+                    .then(() => {
                         successNotify('Successfully created role!')
-                        void router.push('/manage/roles')
+                        setTimeout(() => {
+                            void router.push('/manage/roles')
+                        }, 1)
                     })
                     .catch(() => {
                         errorNotify('There was an Error!')

--- a/frontend/components/organisms/TagsAction/index.tsx
+++ b/frontend/components/organisms/TagsAction/index.tsx
@@ -11,10 +11,14 @@ type Props = {
     id: number
     name: string
     description: string
-    refetchHandler: () => void
+    refetchHandler: (isDelete?: boolean) => void
 }
 
-const renderDeleteAction = (id: number, name: string, refetch: () => void): JSX.Element => {
+const renderDeleteAction = (
+    id: number,
+    name: string,
+    refetch: (isDelete?: boolean) => void
+): JSX.Element => {
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     const [deleteTag] = useMutation(DELETE_TAG)
 
@@ -26,7 +30,7 @@ const renderDeleteAction = (id: number, name: string, refetch: () => void): JSX.
         deleteTag({ variables: { id } })
             .then(() => {
                 successNotify('Tag deleted.')
-                refetch()
+                refetch(true)
             })
             .catch(() => {
                 errorNotify('Failed to delete tag.')

--- a/frontend/helpers/graphql/queries/get_tags.ts
+++ b/frontend/helpers/graphql/queries/get_tags.ts
@@ -8,6 +8,7 @@ const GET_TAGS = gql`
                 currentPage
                 hasMorePages
                 total
+                count
             }
             data {
                 id

--- a/frontend/pages/manage/tags/index.tsx
+++ b/frontend/pages/manage/tags/index.tsx
@@ -76,12 +76,15 @@ const Tags: NextPage = () => {
         setIsOpen(false)
     }
 
-    const refetchHandler = (): void => {
+    const refetchHandler = (isDelete = false): void => {
         void refetch({
             first: 6,
-            page: pageInfo.currentPage,
             name: '%%',
             sort: [{ column: 'POPULARITY', order: 'DESC' }],
+            page:
+                isDelete && paginatorInfo.count === 1 && paginatorInfo.currentPage > 1
+                    ? paginatorInfo.currentPage - 1
+                    : paginatorInfo.currentPage,
         })
     }
 


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-386

## Commands
none

## Pre-conditions
none

## Expected Output

- [x] If a page has only one tag, the user should be redirected to the previous page after that tag is deleted.

## Notes
none

## Screenshots
<img width="956" alt="image" src="https://user-images.githubusercontent.com/116238730/227874049-37ad6694-6547-4f09-a615-d68ffd09bc71.png">
<img width="943" alt="image" src="https://user-images.githubusercontent.com/116238730/227874097-30557c46-db55-4fbd-886b-4b931d8370f5.png">