### PR TITLE
[Overflow-387] [BUGFIX] Show title in bookmark questions and reposition the bookmark icon

### DIFF
--- a/frontend/components/molecules/Bookmark/index.tsx
+++ b/frontend/components/molecules/Bookmark/index.tsx
@@ -1,9 +1,8 @@
 import Icons from '@/components/atoms/Icons'
-import { useMutation } from '@apollo/client'
 import TOGGLE_BOOKMARK from '@/helpers/graphql/mutations/toggle_bookmark'
-import { successNotify } from '@/helpers/toast'
-import { useState } from 'react'
 import GET_BOOKMARKS from '@/helpers/graphql/queries/get_bookmarks'
+import { successNotify } from '@/helpers/toast'
+import { useMutation } from '@apollo/client'
 
 type BookmarkProps = {
     is_bookmarked: boolean
@@ -22,8 +21,6 @@ const Bookmark = ({
         refetchQueries: [{ query: GET_BOOKMARKS }, 'Bookmarks'],
     })
 
-    const [isBookmarked, setIsBookmarked] = useState(is_bookmarked)
-
     const handleClick = (): void => {
         toggleBookmark({
             variables: {
@@ -32,7 +29,6 @@ const Bookmark = ({
             },
         })
             .then((data: any) => {
-                setIsBookmarked(!isBookmarked)
                 successNotify(data.data.toggleBookmark)
             })
             .catch(() => {})
@@ -48,7 +44,7 @@ const Bookmark = ({
                 handleClick()
             }}
         >
-            <Icons name={isBookmarked ? 'bookmark_fill' : 'bookmark_outline'} />
+            <Icons name={is_bookmarked ? 'bookmark_fill' : 'bookmark_outline'} />
         </button>
     )
 }

--- a/frontend/components/organisms/AnswerBookmark/index.tsx
+++ b/frontend/components/organisms/AnswerBookmark/index.tsx
@@ -1,4 +1,5 @@
 import Author from '@/components/molecules/Author'
+import Bookmark from '@/components/molecules/Bookmark'
 import { parseHTML } from '@/helpers/htmlParsing'
 import type { BookmarkType } from '@/pages/users/[slug]'
 import Link from 'next/link'
@@ -21,14 +22,24 @@ const AnswerBookmark = ({ id, bookmarkable }: BookmarkType): JSX.Element => {
                 view_count={question?.views_count}
                 tags={question?.tags ?? []}
                 user={question?.user}
-                bookmarkType="Answer"
-                bookmarkAnswerId={bookmarkable?.id}
             />
             <div className="px-10 py-3">
                 <div className="flex w-full flex-col border-l-4 border-primary-gray px-4">
-                    <div className="text-sm">
-                        {bookmarkable?.vote_count}{' '}
-                        {bookmarkable?.vote_count !== 1 ? 'Votes' : 'Vote'}
+                    <div className="flex items-center justify-between">
+                        <div className="text-sm">
+                            {bookmarkable?.vote_count}{' '}
+                            {bookmarkable?.vote_count !== 1 ? 'Votes' : 'Vote'}
+                        </div>
+                        <div>
+                            {bookmarkable && (
+                                <Bookmark
+                                    bookmarkable_id={bookmarkable.id}
+                                    bookmarkable_type={'Answer'}
+                                    refetchHandler={() => {}}
+                                    is_bookmarked
+                                />
+                            )}
+                        </div>
                     </div>
                     <div>{parseHTML(bookmarkable?.content)}</div>
                     <div className="flex w-full flex-row justify-between">

--- a/frontend/components/organisms/AnswerBookmark/index.tsx
+++ b/frontend/components/organisms/AnswerBookmark/index.tsx
@@ -13,7 +13,7 @@ const AnswerBookmark = ({ id, bookmarkable }: BookmarkType): JSX.Element => {
             <QuestionList
                 id={question?.id}
                 title={question?.title}
-                slug={question?.slug}
+                question_slug={question?.slug}
                 content={question?.content}
                 created_at={question?.created_at}
                 humanized_created_at={question?.humanized_created_at}

--- a/frontend/components/organisms/BookmarkList/index.tsx
+++ b/frontend/components/organisms/BookmarkList/index.tsx
@@ -1,6 +1,6 @@
+import type { BookmarkType } from '@/pages/users/[slug]'
 import AnswerBookmark from '../AnswerBookmark'
 import QuestionList from '../QuestionList'
-import type { BookmarkType } from '@/pages/users/[slug]'
 
 const BookmarkList = ({ id, bookmarkable }: BookmarkType): JSX.Element => {
     switch (bookmarkable?.__typename) {
@@ -10,7 +10,7 @@ const BookmarkList = ({ id, bookmarkable }: BookmarkType): JSX.Element => {
                     key={id}
                     id={bookmarkable.id}
                     title={bookmarkable.title}
-                    slug={bookmarkable.slug}
+                    question_slug={bookmarkable.slug}
                     content={bookmarkable.content}
                     created_at={bookmarkable.created_at}
                     humanized_created_at={bookmarkable.humanized_created_at}

--- a/frontend/components/organisms/QuestionList/index.tsx
+++ b/frontend/components/organisms/QuestionList/index.tsx
@@ -20,7 +20,6 @@ type Props = {
     tags: TagType[]
     user?: UserType
     bookmarkType?: 'Question' | 'Answer'
-    bookmarkAnswerId?: number
     page_slug?: string
     previous_page_slug?: string
     question_slug?: string
@@ -44,7 +43,6 @@ const QuestionList = ({
     tags,
     user,
     bookmarkType,
-    bookmarkAnswerId = 0,
     previous_page_slug,
     page_slug,
     team_name,
@@ -91,24 +89,28 @@ const QuestionList = ({
                 </div>
             </div>
             <div className="flex w-[85%] flex-col gap-4">
-                <div className="flex w-full justify-between">
-                    {page_slug === 'teams'
-                        ? renderTeamQuestionDetailHeader()
-                        : page_slug === 'questions' && renderQuestionDetailHeader()}
-                    {bookmarkType && (
-                        <Bookmark
-                            bookmarkable_id={bookmarkType === 'Answer' ? bookmarkAnswerId : id}
-                            bookmarkable_type={bookmarkType}
-                            refetchHandler={() => {}}
-                            is_bookmarked
-                        />
-                    )}
-                    {slug && (
-                        <div className="flex items-center gap-2">
-                            <span>{is_public ? 'Public' : 'Private'} </span>
-                            <Icons name={is_public ? 'public' : 'private'} />
-                        </div>
-                    )}
+                <div>
+                    <div className="flex justify-end">
+                        {bookmarkType === 'Question' && (
+                            <Bookmark
+                                bookmarkable_id={id}
+                                bookmarkable_type={bookmarkType}
+                                refetchHandler={() => {}}
+                                is_bookmarked
+                            />
+                        )}
+                    </div>
+                    <div className="flex w-full justify-between ">
+                        {page_slug === 'teams'
+                            ? renderTeamQuestionDetailHeader()
+                            : renderQuestionDetailHeader()}
+                        {slug && (
+                            <div className="flex items-center gap-2">
+                                <span>{is_public ? 'Public' : 'Private'} </span>
+                                <Icons name={is_public ? 'public' : 'private'} />
+                            </div>
+                        )}
+                    </div>
                 </div>
                 <div className="ql-snow flex w-full flex-col gap-1">
                     <div className="ql-editor question-parsed-content w-full">


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-387

## Commands
Go to profile then bookmarks

## Pre-conditions

## Expected Output
- [x] The question title should already be displayed
- [x] The bookmark icon for a question is repositioned at the top of the `Private/Public` text
- [x] The bookmark icon for an answer is repositioned in the answer component instead of in the question component

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/111732984/227910156-3b034fec-3af2-4e37-a8fb-7dcd919b10c6.png)
