### PR TITLE
[OVERFLOW-405] - Refactor Admin tables

### DIFF
--- a/backend/app/GraphQL/Queries/Teams.php
+++ b/backend/app/GraphQL/Queries/Teams.php
@@ -13,7 +13,7 @@ final class Teams
      */
     public function __invoke($_, array $args)
     {
-        $query = Team::query();
+        $query = Team::query()->orderBy('created_at', 'desc');
 
         if ($args['isAdmin']) {
             return $query;

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -36,8 +36,10 @@ class Team extends Model
         });
     }
 
-    protected $appends = ['members_count', 'is_team_leader', 'questions_asked',
-        'questions answered', 'truncated_name', 'truncated_description'];
+    protected $appends = [
+        'members_count', 'is_team_leader', 'questions_asked',
+        'questions answered', 'truncated_name', 'truncated_description',
+    ];
 
     protected $guarded = [];
 
@@ -78,11 +80,11 @@ class Team extends Model
 
     public function getTruncatedNameAttribute()
     {
-        return Str::limit($this->name, 15, '...');
+        return Str::limit($this->name, 45, '...');
     }
 
     public function getTruncatedDescriptionAttribute()
     {
-        return Str::limit($this->description, 50, '...');
+        return Str::limit($this->description, 70, '...');
     }
 }

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -38,7 +38,7 @@ class Team extends Model
 
     protected $appends = [
         'members_count', 'is_team_leader', 'questions_asked',
-        'questions answered', 'truncated_name', 'truncated_description',
+        'questions_answered', 'truncated_name', 'truncated_description',
     ];
 
     protected $guarded = [];

--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -1,20 +1,20 @@
+import { FaLock, FaLockOpen } from 'react-icons/fa'
 import {
-    HiPencilAlt,
     HiBookmark,
-    HiEye,
-    HiChevronDown,
-    HiSearch,
-    HiX,
-    HiTrash,
     HiChevronDoubleLeft,
     HiChevronDoubleRight,
+    HiChevronDown,
     HiChevronLeft,
     HiChevronRight,
+    HiEye,
+    HiPencilAlt,
+    HiSearch,
+    HiTrash,
+    HiX,
 } from 'react-icons/hi'
 import { HiCheck } from 'react-icons/hi2'
-import { IoMdArrowDropup, IoMdArrowDropdown } from 'react-icons/io'
-import { MdOutlineModeEditOutline, MdModeEditOutline } from 'react-icons/md'
-import { FaLockOpen, FaLock } from 'react-icons/fa'
+import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io'
+import { MdModeEditOutline, MdOutlineModeEditOutline } from 'react-icons/md'
 
 type IconsProps = {
     name: string
@@ -25,27 +25,9 @@ type IconsProps = {
 const Icons = ({ name, size = '20', additionalClass = '' }: IconsProps): JSX.Element => {
     switch (name) {
         case 'table_edit':
-            return (
-                <MdModeEditOutline
-                    size={22}
-                    className={`${
-                        additionalClass?.includes('fill')
-                            ? additionalClass
-                            : `${additionalClass} fill-primary-red`
-                    }`}
-                />
-            )
+            return <MdModeEditOutline size={20} className="fill-blue-800" />
         case 'table_delete':
-            return (
-                <HiTrash
-                    size={22}
-                    className={`${
-                        additionalClass?.includes('fill')
-                            ? additionalClass
-                            : `${additionalClass} fill-primary-red`
-                    }`}
-                />
-            )
+            return <HiTrash size={20} className="fill-primary-red" />
         case 'square_edit':
             return <HiPencilAlt size="28" className="cursor-pointer fill-primary-red" />
         case 'vote_up':

--- a/frontend/components/molecules/PermissionPill/index.tsx
+++ b/frontend/components/molecules/PermissionPill/index.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 const PermissionPill = ({ children }: Props): JSX.Element => {
     return (
-        <div className="flex w-fit min-w-fit flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal !outline-none">
+        <div className="flex w-fit min-w-fit flex-row items-center gap-1 rounded-full bg-primary-red py-1 px-3 text-xs font-normal text-white !outline-none">
             <span>{children}</span>
         </div>
     )

--- a/frontend/components/organisms/EditRole/index.tsx
+++ b/frontend/components/organisms/EditRole/index.tsx
@@ -16,7 +16,7 @@ const EditRole = ({ slug }: Props): JSX.Element => {
                     void router.push(`roles/${slug}/edit`)
                 }}
             >
-                <Icons name="table_edit" additionalClass="fill-gray-500" />
+                <Icons name="table_edit" />
             </Button>
         </div>
     )

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -28,7 +28,7 @@ const renderClickable = (
     }
     return (
         <span
-            className="cursor-pointer text-blue-500 underline hover:text-blue-400"
+            className="text-l cursor-pointer text-left font-semibold text-gray-800 hover:text-primary-red"
             onClick={handleClick}
         >
             {text}
@@ -44,80 +44,75 @@ const Table = ({
     clickableArr = [],
 }: TableProps): JSX.Element => {
     return (
-        <div className="flex flex-col  border-black">
-            <div className="-m-1.5 overflow-x-auto">
-                <div className="inline-block min-w-full p-1.5 align-middle">
-                    <div className="overflow-hidden">
-                        <table className="min-w-full divide-y divide-black">
-                            <thead className="bg-primary-gray">
-                                <tr>
-                                    {columns.map((column) => (
-                                        <th
-                                            key={column.key}
-                                            scope="col"
-                                            style={{
-                                                width: column.width,
-                                            }}
-                                            className={`font-se py-3 text-center text-sm font-semibold uppercase ${
-                                                column.key === 'action' ? 'pl-9' : ''
-                                            }`}
-                                        >
-                                            {column.title}
-                                        </th>
-                                    ))}
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-black">
-                                {dataSource.length > 0 ? (
-                                    dataSource.map((data, key) => {
-                                        return (
-                                            <tr key={key} className="hover:bg-light-gray">
-                                                {columns.map((column, key) => {
-                                                    const clickable = clickableArr.find(
-                                                        (item) => item.column === column.key
-                                                    )
-                                                    if (column.key === 'action' && actions) {
-                                                        return (
-                                                            <td
-                                                                key={key}
-                                                                className="whitespace-nowrap py-4 px-8"
-                                                            >
-                                                                {actions(Number(data.key))}
-                                                            </td>
-                                                        )
-                                                    }
-                                                    return (
-                                                        <td
-                                                            key={key}
-                                                            className="min-w-[200px] whitespace-nowrap py-4 text-center text-sm"
-                                                        >
-                                                            {clickable !== undefined
-                                                                ? renderClickable(
-                                                                      data[column.key],
-                                                                      clickable,
-                                                                      data.slug as string
-                                                                  )
-                                                                : data[column.key]}
-                                                        </td>
-                                                    )
-                                                })}
-                                            </tr>
-                                        )
-                                    })
-                                ) : (
-                                    <tr>
-                                        <td
-                                            colSpan={columns.length}
-                                            className="w-full py-10 text-center text-lg font-bold text-primary-gray"
-                                        >
-                                            {isEmptyString}
-                                        </td>
+        <div className="w-full place-self-center overflow-hidden rounded-md pt-4">
+            <div className="relative overflow-x-auto border-2 shadow-md sm:rounded-lg">
+                <table className="w-full text-center text-sm text-gray-500 dark:text-gray-400">
+                    <thead className="bg-gray-200 uppercase text-gray-800 ">
+                        <tr>
+                            {columns.map((column) => (
+                                <th
+                                    key={column.key}
+                                    scope="col"
+                                    style={{
+                                        width: column.width,
+                                    }}
+                                    className={`px-6 py-3 ${
+                                        column.key === 'name' ? 'text-left' : ''
+                                    }`}
+                                >
+                                    {column.title}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {dataSource.length > 0 ? (
+                            dataSource.map((data, key) => {
+                                return (
+                                    <tr
+                                        key={key}
+                                        className="cursor-default border-b bg-white text-gray-600 hover:bg-gray-50"
+                                    >
+                                        {columns.map((column, key) => {
+                                            const clickable = clickableArr.find(
+                                                (item) => item.column === column.key
+                                            )
+                                            if (column.key === 'action' && actions) {
+                                                return (
+                                                    <td key={key} className="px-6 py-4">
+                                                        {actions(Number(data.key))}
+                                                    </td>
+                                                )
+                                            }
+                                            return (
+                                                <td
+                                                    key={key}
+                                                    className={`whitespace-nowrap px-6 py-4  ${
+                                                        column.key === 'name' ? 'text-left' : ''
+                                                    } `}
+                                                >
+                                                    {clickable !== undefined
+                                                        ? renderClickable(
+                                                              data[column.key],
+                                                              clickable,
+                                                              data.slug as string
+                                                          )
+                                                        : data[column.key]}
+                                                </td>
+                                            )
+                                        })}
                                     </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                                )
+                            })
+                        ) : (
+                            <tr>
+                                <td colSpan={columns.length} className="px-6 py-4">
+                                    {isEmptyString}
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
             </div>
         </div>
     )

--- a/frontend/components/organisms/TagsAction/index.tsx
+++ b/frontend/components/organisms/TagsAction/index.tsx
@@ -87,7 +87,7 @@ const TagsActions = ({ id, name, description, refetchHandler }: Props): JSX.Elem
                     setShowEditModal(true)
                 }}
             >
-                <Icons name="table_edit" additionalClass="fill-gray-500" />
+                <Icons name="table_edit" />
             </Button>
             <TagsFormModal
                 isOpen={showEditModal}

--- a/frontend/components/templates/MemberManage.tsx
+++ b/frontend/components/templates/MemberManage.tsx
@@ -225,7 +225,7 @@ const MemberManage = ({ isForAdmin = false }: Props): JSX.Element => {
     }
 
     return (
-        <div className="flex w-full flex-col gap-4 divide-y-2">
+        <div className="flex w-full flex-col gap-4 divide-y-8 ">
             {!isForAdmin && <h1 className="text-3xl font-bold">{team?.name}</h1>}
             <div className="flex h-full flex-col gap-4">
                 <div className="mt-4 flex items-center justify-between">
@@ -300,13 +300,13 @@ const MemberManage = ({ isForAdmin = false }: Props): JSX.Element => {
                         </Modal>
                     )}
                 </div>
-                <div className="overflow-hidden border border-black">
-                    <Table
-                        columns={columns}
-                        dataSource={parseGetMembers(memberList)}
-                        actions={getManageMemberActions}
-                    />
-                </div>
+
+                <Table
+                    columns={columns}
+                    dataSource={parseGetMembers(memberList)}
+                    actions={getManageMemberActions}
+                />
+
                 <div className="mt-auto">
                     {paginatorInfo.lastPage > 1 && (
                         <Paginate {...paginatorInfo} onPageChange={onPageChange} />

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -51,7 +51,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
                     <div
                         className={`flex h-screen ${
                             hideRightSidebarInPages.includes(router.pathname)
-                                ? 'w-full pt-20'
+                                ? 'w-5/6 pt-20'
                                 : routeIfLoginPathCheck
                                 ? 'w-full'
                                 : 'w-4/6 pt-20'

--- a/frontend/pages/manage/roles/index.tsx
+++ b/frontend/pages/manage/roles/index.tsx
@@ -107,10 +107,10 @@ const RolesPage = (): JSX.Element => {
     }
 
     return (
-        <div className="flex w-full flex-col gap-4 p-8">
-            <div className="flex h-full flex-col gap-4">
-                <div className="mt-4 flex items-center justify-between">
-                    <h1 className="text-3xl font-bold">User Roles</h1>
+        <div className="flex w-full flex-col">
+            <div className="flex h-full flex-col">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-3xl font-bold text-gray-800">User Roles</h1>
                     <Button
                         onClick={() => {
                             void router.push('/manage/roles/create')
@@ -119,13 +119,11 @@ const RolesPage = (): JSX.Element => {
                         Add Role
                     </Button>
                 </div>
-                <div className="overflow-hidden border border-black">
-                    <Table
-                        columns={columns}
-                        dataSource={getRolesDataTable(roles)}
-                        actions={getRolesActions}
-                    />
-                </div>
+                <Table
+                    columns={columns}
+                    dataSource={getRolesDataTable(roles)}
+                    actions={getRolesActions}
+                />
                 <div className="mt-auto">
                     {pageInfo.lastPage > 1 && (
                         <Paginate {...pageInfo} onPageChange={onPageChange} />

--- a/frontend/pages/manage/tags/index.tsx
+++ b/frontend/pages/manage/tags/index.tsx
@@ -116,10 +116,10 @@ const Tags: NextPage = () => {
     }
 
     return (
-        <div className="flex w-full flex-col gap-4 p-8">
-            <div className="flex h-full flex-col gap-4">
-                <div className="mt-4 flex items-center justify-between">
-                    <h1 className="text-3xl font-bold">Tags</h1>
+        <div className="flex w-full flex-col">
+            <div className="flex h-full flex-col">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-3xl font-bold text-gray-800">Tags</h1>
                     <Button
                         type="button"
                         onClick={() => {
@@ -129,13 +129,11 @@ const Tags: NextPage = () => {
                         New Tag
                     </Button>
                 </div>
-                <div className="overflow-hidden border border-black">
-                    <Table
-                        columns={columns}
-                        dataSource={getTagsDataTable(tags)}
-                        actions={getTagsActions}
-                    />
-                </div>
+                <Table
+                    columns={columns}
+                    dataSource={getTagsDataTable(tags)}
+                    actions={getTagsActions}
+                />
                 <TagsFormModal isOpen={isOpen} closeModal={closeModal} refetchHandler={refetch} />
                 <div className="mt-auto">{renderPagination()}</div>
             </div>

--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -68,7 +68,7 @@ const TeamDetail = (): JSX.Element => {
 
     const renderMembers = (): JSX.Element => {
         return (
-            <div className="h-[70%] w-[85%]">
+            <div className="h-[70%] w-[93%]">
                 <MemberManage isForAdmin={true} />{' '}
             </div>
         )
@@ -76,7 +76,7 @@ const TeamDetail = (): JSX.Element => {
 
     const renderQuestions = (): JSX.Element => {
         return (
-            <div className="h-[70%] w-[85%] pt-5">
+            <div className="h-[70%] w-[93%] pt-5">
                 <QuestionsPageLayout
                     refetch={questionsApi.refetch}
                     data={questionsApi.data}
@@ -97,7 +97,7 @@ const TeamDetail = (): JSX.Element => {
     }
 
     return (
-        <div className="mx-10 mt-10 w-full flex-col">
+        <div className=" w-full flex-col">
             <div className="flex">
                 <div className="w-full flex-col">
                     <div className="text-3xl font-medium">{team?.truncated_name}</div>

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -62,7 +62,7 @@ const EditAction = ({ team, refetch }: { team?: DataType; refetch: () => void })
                     setShowModal(true)
                 }}
             >
-                <Icons name="table_edit" additionalClass="fill-gray-500" />
+                <Icons name="table_edit" />
             </Button>
             <TeamsFormModal
                 initialData={{

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -234,9 +234,9 @@ const AdminTeams = (): JSX.Element => {
     }
 
     return (
-        <div className="flex h-full w-full flex-col gap-4 p-8">
-            <div className="mt-4 flex flex-row items-center justify-between">
-                <h1 className="text-3xl font-bold">Teams</h1>
+        <div className="flex flex-col">
+            <div className="flex w-full flex-row items-center justify-between">
+                <h1 className="text-3xl font-bold text-gray-800">Teams</h1>
                 <Button
                     type="button"
                     additionalClass="px-6 py-3"
@@ -247,15 +247,14 @@ const AdminTeams = (): JSX.Element => {
                     New Team
                 </Button>
             </div>
-            <div className="TableContainer overflow-hidden border border-[#555555]">
-                <Table
-                    columns={columns}
-                    dataSource={getTeamDataTable(teamArr)}
-                    isEmptyString="No Teams to Show"
-                    actions={renderTeamsActions}
-                    clickableArr={clickableArr}
-                />
-            </div>
+
+            <Table
+                columns={columns}
+                dataSource={getTeamDataTable(teamArr)}
+                isEmptyString="No Teams to Show"
+                actions={renderTeamsActions}
+                clickableArr={clickableArr}
+            />
             <div className="mt-auto">
                 <Paginate {...paginatorInfo} onPageChange={onPageChange} />
             </div>

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -155,7 +155,7 @@ const AdminUsers = (): JSX.Element => {
                     })
                 }}
             >
-                <Icons name="table_edit" additionalClass="fill-gray-500" />
+                <Icons name="table_edit" />
             </Button>
         )
     }

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -181,46 +181,45 @@ const AdminUsers = (): JSX.Element => {
     }
 
     return (
-        <div className="flex w-full flex-col gap-4 p-8">
-            <div className="flex h-full flex-col gap-4">
-                <div className="mt-4 flex items-center">
-                    <h1 className="text-3xl font-bold">Users</h1>
+        <div className="flex w-full flex-col">
+            <div className="flex h-full flex-col">
+                <div className="flex items-center">
+                    <h1 className="text-3xl font-bold text-gray-800">Users</h1>
                 </div>
-                <div className="overflow-hidden border border-secondary-black">
-                    <Table
-                        columns={columns}
-                        dataSource={newUserArr}
-                        actions={editAction}
-                        clickableArr={clickableArr}
-                    />
-                    {isOpenEdit && (
-                        <Modal
-                            title={`Assign Role`}
-                            submitLabel="Save"
-                            isOpen={isOpenEdit}
-                            handleClose={closeEdit}
-                            handleSubmit={handleSubmit(onSubmit)}
-                        >
-                            <form>
-                                <Controller
-                                    control={control}
-                                    name="role"
-                                    defaultValue={1}
-                                    render={({ field: { onChange, value } }) => (
-                                        <Dropdown
-                                            key="role-select"
-                                            name="role"
-                                            label=""
-                                            options={roles}
-                                            onChange={onChange}
-                                            value={value}
-                                        />
-                                    )}
-                                />
-                            </form>
-                        </Modal>
-                    )}
-                </div>
+                <Table
+                    columns={columns}
+                    dataSource={newUserArr}
+                    actions={editAction}
+                    clickableArr={clickableArr}
+                />
+                {isOpenEdit && (
+                    <Modal
+                        title={`Assign Role`}
+                        submitLabel="Save"
+                        isOpen={isOpenEdit}
+                        handleClose={closeEdit}
+                        handleSubmit={handleSubmit(onSubmit)}
+                    >
+                        <form>
+                            <Controller
+                                control={control}
+                                name="role"
+                                defaultValue={1}
+                                render={({ field: { onChange, value } }) => (
+                                    <Dropdown
+                                        key="role-select"
+                                        name="role"
+                                        label=""
+                                        options={roles}
+                                        onChange={onChange}
+                                        value={value}
+                                    />
+                                )}
+                            />
+                        </form>
+                    </Modal>
+                )}
+
                 {paginatorInfo.lastPage > 1 && (
                     <Paginate {...paginatorInfo} onPageChange={onPageChange} />
                 )}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-405
## Commands
None
## Pre-conditions
None
## Expected Output
- The new table component is implemented in 
    - Manage Team Page and Members Tab in the Manage Team detail page
    - Mange Roles
    - Manage Tags
    - Manage Users
- The default sort for Admin Team Table  is Most Recent
   - Adding a new team will redirect to the manage team detail page
   - Viewing the team table, the NEW ADDED team is on the top of the list

## Notes

title text - text-3xl font-bold text-gray-800
delete icon - size 20 fill-blue-800
edit icon - size 20 fill-primary-red

## Screenshots
table Team Page
![image](https://user-images.githubusercontent.com/112840596/229043326-871a6a8d-57ef-4034-9303-5f9c2a2466eb.png)

Table in Members Tab Manage Team detail page
![image](https://user-images.githubusercontent.com/112840596/229043389-0412911c-f746-440d-952a-4b0c5f795b96.png)


table Tags Page
![image](https://user-images.githubusercontent.com/112840596/229043430-1bc0c9f8-c9a1-4b7f-b570-74cec2fb62d3.png)


table Role Page
![image](https://user-images.githubusercontent.com/112840596/229043461-545a7089-81d8-4ad8-ace8-24388d317a06.png)


table Users Page
![image](https://user-images.githubusercontent.com/112840596/229043513-dfc174b7-7eea-4ba6-921b-cf8b3966478b.png)

