### PR TITLE
[Overflow-404] Refactor Admin Tags Page

### DIFF
--- a/backend/graphql/tag/query.graphql
+++ b/backend/graphql/tag/query.graphql
@@ -23,6 +23,7 @@ input tagSort {
 
 enum TAG_COLUMNS {
     CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
     NAME @enum(value: "name")
     POPULARITY @enum(value: "questions_count")
     WATCH_COUNT @enum(value: "users_watching_count")

--- a/frontend/components/molecules/SidebarButton/index.tsx
+++ b/frontend/components/molecules/SidebarButton/index.tsx
@@ -21,6 +21,8 @@ const SidebarButton = ({ IconName, Text, subMenu, url }: SidebarButtonProps): an
     const isSelected = (index: number, urlString: string): boolean => {
         const urlSplit = router.pathname.split('/')
 
+        if (!urlSplit[index]) return urlString.includes('questions')
+
         return urlString.includes(urlSplit[index])
     }
 

--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -104,6 +104,7 @@ const TagsFormModal = ({
                     name="tagDescription"
                     label="Description"
                     defaultValue={initialData.description || ''}
+                    className="focus:ring-0"
                 />
             </form>
         </Modal>

--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -3,6 +3,7 @@ import CREATE_TAG from '@/helpers/graphql/mutations/create_tag'
 import UPDATE_TAG from '@/helpers/graphql/mutations/update_tag'
 import { errorNotify, successNotify } from '@/helpers/toast'
 import { useMutation } from '@apollo/client'
+import { Input, Textarea } from '@material-tailwind/react'
 import React from 'react'
 const tempData = {
     id: 0,
@@ -81,6 +82,7 @@ const TagsFormModal = ({
             }
         }
     }
+
     return (
         <Modal
             title={formTitle}
@@ -91,27 +93,18 @@ const TagsFormModal = ({
             }}
         >
             <form className="flex w-full flex-col gap-4 " onSubmit={onSubmit}>
-                <div className="flex flex-col gap-2">
-                    <input
-                        name="tagName"
-                        type="text"
-                        id="tagName"
-                        className="rounded-lg"
-                        placeholder="Name"
-                        defaultValue={initialData.name || ''}
-                    />
-                </div>
-
-                <div className="flex flex-col gap-2">
-                    <textarea
-                        name="tagDescription"
-                        id="tagDescription"
-                        className="rounded-lg"
-                        placeholder="Briefly Describe the Tag"
-                        defaultValue={initialData.description || ''}
-                        rows={4}
-                    />
-                </div>
+                <Input
+                    id="tagName"
+                    name="tagName"
+                    label="Name"
+                    defaultValue={initialData.name || ''}
+                />
+                <Textarea
+                    id="tagDescription"
+                    name="tagDescription"
+                    label="Description"
+                    defaultValue={initialData.description || ''}
+                />
             </form>
         </Modal>
     )

--- a/frontend/components/organisms/TeamsFormModal/index.tsx
+++ b/frontend/components/organisms/TeamsFormModal/index.tsx
@@ -157,6 +157,7 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
                             label="Description"
                             value={value}
                             onChange={onChange}
+                            className="focus:ring-0"
                         />
                     )}
                 />

--- a/frontend/components/organisms/TeamsFormModal/index.tsx
+++ b/frontend/components/organisms/TeamsFormModal/index.tsx
@@ -6,6 +6,7 @@ import GET_ALL_TEAM_LEADERS from '@/helpers/graphql/queries/get_all_team_leaders
 import type { UserType } from '@/pages/questions/[slug]'
 import type { FetchResult } from '@apollo/client'
 import { useMutation, useQuery } from '@apollo/client'
+import { Input, Textarea } from '@material-tailwind/react'
 import { useRouter } from 'next/router'
 import { Controller, useForm } from 'react-hook-form'
 import { errorNotify, successNotify } from '../../../helpers/toast'
@@ -15,6 +16,7 @@ type FormProps = {
     initialData?: {
         id: number
         title: string
+        teamLeaderId: number
         description: string
     }
     isOpen: boolean
@@ -22,11 +24,17 @@ type FormProps = {
     refetch: () => void
 }
 
+type FormValues = {
+    teamName: string
+    teamLeader: number
+    teamDescription: string
+}
+
 const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps): JSX.Element => {
     const router = useRouter()
     const formTitle = initialData?.title ? 'Edit Team' : 'Add Team'
 
-    const { control } = useForm<{ teamLeader: number }>({})
+    const { handleSubmit, control } = useForm<FormValues>({})
     const { data } = useQuery(GET_ALL_TEAM_LEADERS)
     const [createTeam] = useMutation(CREATE_TEAM)
     const [updateTeam] = useMutation(UPDATE_TEAM)
@@ -38,25 +46,21 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
         })
     )
 
-    const onSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
-        const target = e.target as typeof e.target & {
-            teamName: { value: string }
-            teamLeader: { value: number }
-            teamDescription: { value: string }
-        }
+    const onSubmit = (data: FormValues): void => {
+        const { teamName, teamLeader, teamDescription } = data
 
-        const name = target.teamName.value
-        const description = target.teamDescription.value
-        const user_id = target.teamLeader.value
-
-        if (!(name && description)) {
+        if (!(teamName && teamLeader && teamDescription)) {
             errorNotify('Please input some data')
             return
         }
 
         if (initialData) {
-            const { title, description: init_desc } = initialData
-            if (title === name && init_desc === description) {
+            const { title, teamLeaderId, description: init_desc } = initialData
+            if (
+                title === teamName &&
+                teamLeaderId === +teamLeader &&
+                init_desc === teamDescription
+            ) {
                 errorNotify('No changes were made!')
                 closeModal()
                 return
@@ -65,9 +69,9 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
             updateTeam({
                 variables: {
                     id: initialData.id,
-                    name,
-                    description,
-                    user_id,
+                    name: teamName,
+                    description: teamDescription,
+                    user_id: teamLeader,
                 },
             })
                 .then(({ data }: FetchResult<{ updateTeam: { id: number; slug: string } }>) => {
@@ -84,9 +88,9 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
         } else {
             createTeam({
                 variables: {
-                    name,
-                    description,
-                    user_id,
+                    name: teamName,
+                    description: teamDescription,
+                    user_id: teamLeader,
                 },
             })
                 .then(({ data }: FetchResult<{ createTeam: { id: number; slug: string } }>) => {
@@ -112,41 +116,50 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
                 closeModal()
             }}
         >
-            <form className="flex w-full flex-col gap-4" onSubmit={onSubmit}>
-                <div className="flex flex-col gap-2">
-                    <input
-                        type="text"
-                        id="teamName"
-                        className="rounded-lg"
-                        placeholder="Name"
-                        defaultValue={initialData?.title ?? ''}
-                    />
-                </div>
-                <div className="flex flex-col gap-2">
-                    <span className="font-bold">Team Leader</span>
-                    <Controller
-                        control={control}
-                        name="teamLeader"
-                        render={({ field: { onChange, value } }) => (
-                            <Dropdown
-                                name="teamLeader"
-                                label=""
-                                options={teamLeaders}
-                                onChange={onChange}
-                                value={value}
-                            />
-                        )}
-                    />
-                </div>
-                <div className="flex flex-col gap-2">
-                    <textarea
-                        id="teamDescription"
-                        className="rounded-lg"
-                        placeholder="Briefly Describe the Team"
-                        defaultValue={initialData?.description ?? ''}
-                        rows={4}
-                    />
-                </div>
+            <form className="flex w-full flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+                <Controller
+                    control={control}
+                    name="teamName"
+                    defaultValue={initialData?.title ?? ''}
+                    render={({ field: { onChange, value } }) => (
+                        <Input
+                            id="teamName"
+                            name="teamName"
+                            label="Name"
+                            value={value}
+                            onChange={onChange}
+                        />
+                    )}
+                />
+                <Controller
+                    control={control}
+                    name="teamLeader"
+                    defaultValue={initialData?.teamLeaderId}
+                    render={({ field: { onChange, value } }) => (
+                        <Dropdown
+                            name="teamLeader"
+                            label="Team Leader"
+                            options={teamLeaders}
+                            onChange={onChange}
+                            value={value}
+                        />
+                    )}
+                />
+
+                <Controller
+                    control={control}
+                    name="teamDescription"
+                    defaultValue={initialData?.description ?? ''}
+                    render={({ field: { onChange, value } }) => (
+                        <Textarea
+                            id="teamDescription"
+                            name="teamDescription"
+                            label="Description"
+                            value={value}
+                            onChange={onChange}
+                        />
+                    )}
+                />
             </form>
         </Modal>
     )

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import QuestionsPage from './questions'
 
 export default function Home(): JSX.Element {
     return (
@@ -12,7 +13,9 @@ export default function Home(): JSX.Element {
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <link rel="icon" href="/favicon.ico" />
             </Head>
-            <main></main>
+            <main>
+                <QuestionsPage />
+            </main>
         </>
     )
 }

--- a/frontend/pages/manage/tags/index.tsx
+++ b/frontend/pages/manage/tags/index.tsx
@@ -41,7 +41,7 @@ const Tags: NextPage = () => {
         variables: {
             first: 6,
             page: 1,
-            sort: [{ column: 'POPULARITY', order: 'DESC' }],
+            sort: [{ column: 'UPDATED_AT', order: 'DESC' }],
         },
     })
 
@@ -50,7 +50,7 @@ const Tags: NextPage = () => {
             first: 6,
             page: 1,
             name: '%%',
-            sort: [{ column: 'POPULARITY', order: 'DESC' }],
+            sort: [{ column: 'UPDATED_AT', order: 'DESC' }],
         })
     }, [router, refetch])
 
@@ -80,7 +80,7 @@ const Tags: NextPage = () => {
         void refetch({
             first: 6,
             name: '%%',
-            sort: [{ column: 'POPULARITY', order: 'DESC' }],
+            sort: [{ column: 'UPDATED_AT', order: 'DESC' }],
             page:
                 isDelete && paginatorInfo.count === 1 && paginatorInfo.currentPage > 1
                     ? paginatorInfo.currentPage - 1

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -22,6 +22,7 @@ type TeamType = {
     members_count: string
     truncated_name: string
     truncated_description: string
+    teamLeader: { id: number }
 }
 
 type TeamsQuery = {
@@ -68,6 +69,7 @@ const EditAction = ({ team, refetch }: { team?: DataType; refetch: () => void })
                 initialData={{
                     id: team?.key as number,
                     title: team?.full_name as string,
+                    teamLeaderId: team?.teamLeaderId as number,
                     description: team?.full_description as string,
                 }}
                 isOpen={showModal}
@@ -189,11 +191,13 @@ const AdminTeams = (): JSX.Element => {
                 description,
                 truncated_description,
                 members_count,
+                teamLeader: { id: teamLeaderId },
             } = team
             return {
                 key: id,
                 slug,
                 members_count,
+                teamLeaderId: +teamLeaderId,
                 name: truncated_name,
                 description: truncated_description,
                 full_name: name,


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-404

## Commands
Go to Admin Tags Page
Try adding a tag or editing an existing tag

## Pre-conditions

## Expected Output
- [x] You should be able to see the new design for the Tag Form Modal
- [x] You should be able to see the new design for the Team Form Modal

## Notes
- The most recently updated tag will be shown first in the list
- I also included the refactor of Admin Teams Page modals
- Dependent on the `feature/refactor-team-leader-page` branch

## Screenshots
Add Tag
![image](https://user-images.githubusercontent.com/111732984/229462272-b85c58a4-4af7-4fb8-a3c8-61ead5fb07f2.png)

Edit Tag
![image](https://user-images.githubusercontent.com/111732984/229462316-d42dac7a-5ccd-4568-b17e-aa7a499bf267.png)

Add Team
![image](https://user-images.githubusercontent.com/111732984/229462158-3f8a7829-e44c-462a-a321-c488c286509a.png)

Edit Team
![image](https://user-images.githubusercontent.com/111732984/229462229-f557e419-d06b-495e-ae12-08405485cadf.png)
