### PR TITLE
[Overflow-396] Refactor Add/Edit Question Page

### DIFF
--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -57,6 +57,8 @@ const getButtonClasses = (usage: string): string => {
             return 'items-center rounded-md border-2 px-4 border-primary-red text-primary-red text-sm hover:bg-light-red py-1'
         case 'modal-submit':
             return 'items-center rounded-md bg-primary-red text-white px-4 text-sm hover:bg-secondary-red py-1'
+        case 'question-form':
+            return 'px-10 inline-flex items-center justify-center rounded-md bg-primary-red p-4 text-center text-sm text-white hover:bg-dark-red focus:outline-none focus:ring-1 focus:ring-red-700'
         default:
             return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 border-red-500 focus:ring-red-600 hover:bg-rose-200'
     }

--- a/frontend/components/molecules/RichTextEditor/index.tsx
+++ b/frontend/components/molecules/RichTextEditor/index.tsx
@@ -1,8 +1,8 @@
-import 'react-quill/dist/quill.snow.css'
 import dynamic from 'next/dynamic'
-import type { ControllerRenderProps } from 'react-hook-form'
 import type { ComponentType } from 'react'
+import type { ControllerRenderProps } from 'react-hook-form'
 import type { ReactQuillProps, Value } from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
 type RTEProps = {
     value: Value
     onChange: ControllerRenderProps['onChange']
@@ -55,7 +55,7 @@ const RichTextEditor = ({
 
     switch (usage) {
         case 'description':
-            style = { height: '10rem' }
+            style = { height: '10rem', marginBottom: '2rem' }
             break
         case 'dashboard':
             style = { minHeight: '100%' }

--- a/frontend/components/molecules/SortDropdown/index.tsx
+++ b/frontend/components/molecules/SortDropdown/index.tsx
@@ -78,7 +78,7 @@ const SortDropdown = ({ grouped = false, selectedFilter, filters }: AppProps): J
                     leaveFrom="transform opacity-100 scale-100"
                     leaveTo="transform opacity-0 scale-95"
                 >
-                    <Menu.Items className="absolute right-0 z-10 mt-1 w-44 divide-y divide-gray-200 rounded-lg bg-white bg-white shadow">
+                    <Menu.Items className="absolute left-0 z-10 mt-1 w-44 divide-y divide-gray-200 rounded-lg bg-white bg-white shadow">
                         {grouped ? renderGroupedFilters() : renderFilters()}
                     </Menu.Items>
                 </Transition>

--- a/frontend/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/components/organisms/QuestionDetail/index.tsx
@@ -63,7 +63,6 @@ const QuestionDetail = ({
     }
 
     const editLink = team_slug ? `/teams/${team_slug}/question/${slug}/edit` : `${slug}/edit`
-
     return (
         <Fragment>
             <div className="flex w-full flex-col">

--- a/frontend/components/templates/layouts/index.tsx
+++ b/frontend/components/templates/layouts/index.tsx
@@ -49,7 +49,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
                             </div>
                         )}
                     <div
-                        className={`flex min-h-screen ${
+                        className={`flex min-h-screen bg-gray-100 ${
                             hideRightSidebarInPages.includes(router.pathname)
                                 ? 'w-5/6 pt-20'
                                 : routeIfLoginPathCheck

--- a/frontend/pages/questions/[slug]/edit.tsx
+++ b/frontend/pages/questions/[slug]/edit.tsx
@@ -1,8 +1,9 @@
 import QuestionForm from '@/components/organisms/QuestionForm'
+import GET_QUESTION_SKELETON from '@/helpers/graphql/queries/get_question_skeleton'
+import { useQuery } from '@apollo/client'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useQuery } from '@apollo/client'
-import GET_QUESTION_SKELETON from '@/helpers/graphql/queries/get_question_skeleton'
+import { IoIosArrowBack } from 'react-icons/io'
 
 const EditQuestionFormPage = (): JSX.Element => {
     const router = useRouter()
@@ -14,13 +15,15 @@ const EditQuestionFormPage = (): JSX.Element => {
         },
     })
     return (
-        <div className="flex w-full flex-col content-center justify-center ">
-            <div className="flex shrink pb-6">
-                <div className="ml-10 pt-10 text-xl text-primary-gray">
-                    <Link href={`/questions/${router.query.slug as string}`}>{'< Go Back'}</Link>
-                </div>
+        <div className="flex flex-col bg-light-gray">
+            <div className="w-full">
+                <Link href={`/questions/${router.query.slug as string}`}>
+                    <div className="flex flex-row items-center text-2xl">
+                        <IoIosArrowBack size={24} /> Go Back
+                    </div>
+                </Link>
             </div>
-            <div className="ml-16 mr-16 w-full content-center lg:w-[80%]">
+            <div className="mt-[80px] flex w-full justify-center ">
                 {!loading && <QuestionForm initialState={data?.question} />}
             </div>
         </div>

--- a/frontend/pages/questions/add.tsx
+++ b/frontend/pages/questions/add.tsx
@@ -1,6 +1,7 @@
 import QuestionForm from '@/components/organisms/QuestionForm'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { IoIosArrowBack } from 'react-icons/io'
 
 const QuestionFormPage = (): JSX.Element => {
     let path
@@ -9,13 +10,15 @@ const QuestionFormPage = (): JSX.Element => {
     else path = `/teams/${router.query.prev as string}`
 
     return (
-        <div className="flex w-full flex-col content-center justify-center ">
-            <div className="flex shrink pb-6">
-                <div className="ml-10 pt-10 text-xl text-primary-gray">
-                    <Link href={path}>{'< Go Back'}</Link>
-                </div>
+        <div className="flex w-full flex-col bg-light-gray">
+            <div className="w-full">
+                <Link href={path}>
+                    <div className="flex flex-row items-center text-2xl">
+                        <IoIosArrowBack size={24} /> Go Back
+                    </div>
+                </Link>
             </div>
-            <div className="ml-16 mr-16 w-full content-center lg:w-[80%]">
+            <div className="mt-[80px] flex w-full justify-center ">
                 <QuestionForm />
             </div>
         </div>

--- a/frontend/pages/teams/[slug]/question/[question-slug]/edit.tsx
+++ b/frontend/pages/teams/[slug]/question/[question-slug]/edit.tsx
@@ -3,6 +3,7 @@ import GET_QUESTION_SKELETON from '@/helpers/graphql/queries/get_question_skelet
 import { useQuery } from '@apollo/client'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { IoIosArrowBack } from 'react-icons/io'
 
 const EditQuestionFormPage = (): JSX.Element => {
     const router = useRouter()
@@ -14,19 +15,19 @@ const EditQuestionFormPage = (): JSX.Element => {
         },
     })
     return (
-        <div className="flex w-full flex-col content-center justify-center ">
-            <div className="flex shrink pb-6">
-                <div className="ml-10 pt-10 text-xl text-primary-gray">
-                    <Link
-                        href={`/teams/${query.slug as string}/question/${
-                            query['question-slug'] as string
-                        }`}
-                    >
-                        {'< Go Back'}
-                    </Link>
-                </div>
+        <div className="flex flex-col bg-light-gray">
+            <div className="w-full">
+                <Link
+                    href={`/teams/${query.slug as string}/question/${
+                        query['question-slug'] as string
+                    }`}
+                >
+                    <div className="flex flex-row items-center text-2xl">
+                        <IoIosArrowBack size={24} /> Go Back
+                    </div>
+                </Link>
             </div>
-            <div className="ml-16 mr-16 w-full content-center lg:w-[80%]">
+            <div className="mt-[80px] flex w-full justify-center ">
                 {!loading && <QuestionForm initialState={data.question} />}
             </div>
         </div>

--- a/frontend/pages/teams/[slug]/question/[question-slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/question/[question-slug]/index.tsx
@@ -34,7 +34,6 @@ const QuestionDetailPage = (): JSX.Element => {
     if (query.check !== '') {
         path = query.check as string
     }
-
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTION, {
         variables: {
             slug: String(query['question-slug']),
@@ -123,6 +122,7 @@ const QuestionDetailPage = (): JSX.Element => {
                         vote_count={question.vote_count}
                         views_count={question.views_count}
                         tags={question.tags}
+                        team_slug={query.slug as string}
                         is_bookmarked={question.is_bookmarked}
                         user_vote={question.user_vote}
                         user={question.user}

--- a/frontend/styles/RichTextEditor.css
+++ b/frontend/styles/RichTextEditor.css
@@ -1,13 +1,27 @@
 .quill .ql-container.ql-snow {
     background-color: white;
     border-radius: 0 0 1em 1em;
-    border-color: rgb(156 163 175);
+    border-color: #eeeeee;
     border-width: 2px;
 }
 
 .quill .ql-toolbar.ql-snow {
     background-color: white;
     border-radius: 1em 1em 0 0;
-    border-color: rgb(156 163 175);
+    border-color: #eeeeee;
     border-width: 2px;
+}
+
+.ql-snow .ql-fill {
+    fill: #adadad !important;
+    stroke: none;
+}
+.ql-toolbar .ql-picker-label,
+.ql-toolbar .ql-picker-options {
+    color: #adadad !important;
+}
+
+.ql-toolbar .ql-stroke:not(.ql-color-label) {
+    fill: none;
+    stroke: #adadad !important;
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-396
## Commands

## Pre-conditions

## Expected Output
For Public Questions:
* All Fields are empty
* Select Teams are Default
* Public checkbox is true and disabled if there's no teams selected

For Private Questions:
* All Fields are empty
* Previous Team is default selected

Both
* CSS for TextEditor is changed to fit with the UI
* Moved Team and Public Option Downward
* Moved refetch for TagsInput to QuestionForm
* Moved the default values for team to initialization instead on validation
## Notes

## Screenshots
`/questions/add`
![image](https://user-images.githubusercontent.com/114897466/229700335-3d49d93d-a518-4485-a26c-6187d0c64a3d.png)

`/questions/[slug]/edit`
![image](https://user-images.githubusercontent.com/114897466/229702235-5403c871-98b5-43c1-b527-381ebed86c32.png)

`/teams/slug/questions/slug/edit`
![image](https://user-images.githubusercontent.com/114897466/229701878-79b51a19-cf60-4e00-8b2e-c9c202de06bb.png)
