### PR TITLE
[Overflow-399] Refactor Teams Page

### DIFF
--- a/frontend/components/atoms/PageHeader/index.tsx
+++ b/frontend/components/atoms/PageHeader/index.tsx
@@ -3,7 +3,7 @@ type Props = {
 }
 
 const PageHeader = ({ children }: Props): JSX.Element => {
-    return <div className="w-full px-5 text-3xl font-bold">{children}</div>
+    return <div className="w-full text-3xl font-bold text-gray-800">{children}</div>
 }
 
 export default PageHeader

--- a/frontend/components/molecules/StackedUsers/index.tsx
+++ b/frontend/components/molecules/StackedUsers/index.tsx
@@ -1,5 +1,12 @@
+import Avatar from 'react-avatar'
 interface StackedUsersProps {
-    images: string[]
+    images: Array<{
+        user: {
+            first_name: string
+            last_name: string
+            avatar: string
+        }
+    }>
 }
 
 const StackedUsers = ({ images }: StackedUsersProps): JSX.Element => {
@@ -10,15 +17,20 @@ const StackedUsers = ({ images }: StackedUsersProps): JSX.Element => {
         images = images.slice(0, 4)
     }
     return (
-        <div className="hidden flex-row -space-x-7 lg:flex">
+        <div className="hidden flex-row -space-x-5 lg:flex">
             {images.length &&
-                images.map((imageUrl, index) => {
+                images.map((image, index) => {
                     return (
-                        <img
+                        <Avatar
                             key={index}
-                            className="h-[40px] w-[40px] rounded-full"
-                            src={imageUrl}
-                            alt="user photo"
+                            round={true}
+                            name={`${image.user.first_name} ${image.user.last_name}`}
+                            size="40"
+                            alt={image.user.first_name}
+                            src={image.user.avatar}
+                            maxInitials={1}
+                            textSizeRatio={2}
+                            className={`flex-0 aspect-square bg-gray-800 text-sm`}
                         />
                     )
                 })}

--- a/frontend/components/molecules/TeamSidebar/index.tsx
+++ b/frontend/components/molecules/TeamSidebar/index.tsx
@@ -6,7 +6,11 @@ interface ITeam {
     id: number
     name: string
     members: Array<{
-        user: { avatar: string }
+        user: {
+            first_name: string
+            last_name: string
+            avatar: string
+        }
     }>
     slug: string
 }
@@ -41,14 +45,15 @@ const TeamSidebar = ({ data, loading = true }: TeamSidebarProps): JSX.Element =>
             setTeams(extractTeams())
         }
     }, [data])
+
     return (
         <div className="mt-4 rounded-br-md rounded-bl-md  drop-shadow-md">
             <div className="flex w-full justify-between rounded-tr-md rounded-tl-md bg-primary-red p-2.5 text-white drop-shadow-md">
                 <span className="text-md">My Teams</span>
             </div>
             <div
-                className={`tags flex max-h-[384px] flex-wrap rounded-br-md rounded-bl-md bg-white ${
-                    teams.length > 0 ? 'overflow-y-scroll' : ''
+                className={`flex max-h-[384px] flex-wrap rounded-br-md rounded-bl-md bg-white ${
+                    teams.length > 0 ? 'overflow-y-auto' : ''
                 }`}
             >
                 {teams.length === 0 && (
@@ -66,35 +71,46 @@ const TeamSidebar = ({ data, loading = true }: TeamSidebarProps): JSX.Element =>
 }
 
 const TeamTab = ({ team }: TeamTabProps): JSX.Element => {
-    const extractImageUrls = (): string[] => {
+    const extractAvatars = (): Array<{
+        user: {
+            first_name: string
+            last_name: string
+            avatar: string
+        }
+    }> => {
         const imageList = Array.from(
             team.members.map((userWrapper) => {
                 const { user } = userWrapper
-                if (user.avatar === null || user.avatar === undefined) {
-                    return 'https://www.w3schools.com/howto/img_avatar.png'
+                return {
+                    user: {
+                        first_name: user.first_name,
+                        last_name: user.last_name,
+                        avatar: user.avatar,
+                    },
                 }
-                return user.avatar
             })
         )
+
         return imageList
     }
+
     if (team !== undefined) {
-        extractImageUrls()
+        extractAvatars()
         return (
             <Link
-                className="flex h-24 w-full items-center justify-between border-b-2 border-b-secondary-gray bg-white px-2 last:rounded-br-md last:rounded-bl-md last:border-b-0 hover:bg-[#E8E8E8]"
+                className="flex h-20 w-full items-center justify-between border-b-2 border-b-secondary-gray bg-white px-2 last:rounded-br-md last:rounded-bl-md last:border-b-0 hover:bg-red-50"
                 href={`/teams/${team.slug}`}
             >
                 <div className="ml-2 flex flex-col overflow-hidden align-middle">
-                    <div className="text-md w-36 overflow-hidden text-ellipsis line-clamp-2 ">
+                    <div className="text-md w-36 overflow-hidden text-ellipsis text-gray-800 line-clamp-2">
                         {team.name}
                     </div>
-                    <div className="text-md hidden md:text-xs lg:flex">
-                        {team.members.length} members
+                    <div className="text-md align-center hidden text-gray-600 md:text-sm lg:flex">
+                        {team.members.length} {team.members.length !== 1 ? 'members' : 'member'}
                     </div>
                 </div>
                 <div className="hidden h-full items-center align-middle xl:flex">
-                    <StackedUsers images={extractImageUrls()} />
+                    <StackedUsers images={extractAvatars()} />
                 </div>
             </Link>
         )

--- a/frontend/helpers/graphql/queries/sidebar.ts
+++ b/frontend/helpers/graphql/queries/sidebar.ts
@@ -14,6 +14,8 @@ export const QTagsTeamSidebar = gql`
                     name
                     members {
                         user {
+                            first_name
+                            last_name
                             avatar
                         }
                     }

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -1,14 +1,15 @@
 import PageHeader from '@/components/atoms/PageHeader'
 import SearchInput from '@/components/molecules/SearchInput'
 import Paginate from '@/components/organisms/Paginate'
-import Card from '@/components/templates/Card'
 import type { PaginatorInfo } from '@/components/templates/QuestionsPageLayout'
 import GET_TEAMS from '@/helpers/graphql/queries/get_teams'
 import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
+import { Card, CardBody, CardFooter, CardHeader, Typography } from '@material-tailwind/react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { BsPeopleFill } from 'react-icons/bs'
 
 type TeamType = {
     id: number
@@ -73,12 +74,24 @@ const TeamsListPage = (): JSX.Element => {
         await userQuery.refetch({ first, page })
     }
 
+    const renderSearchResultHeader = (): JSX.Element => {
+        return (
+            <div className="w-80">
+                <div className="truncate px-2 pt-1 text-sm text-gray-600">
+                    {`${pageInfo.total} search ${
+                        pageInfo.total !== 1 ? `results` : `result`
+                    } for "${term}"`}
+                </div>
+            </div>
+        )
+    }
+
     return (
-        <div className="flex h-full w-full flex-col gap-3 divide-y-2 divide-primary-gray px-10 pt-8 pb-5">
+        <div className="flex h-full w-full flex-col">
             <PageHeader>Teams</PageHeader>
-            <div className="flex h-full w-full flex-col gap-2 px-5 pt-3">
-                <div className="flex w-full flex-row items-center justify-between">
-                    <div className="mt-2 flex flex-row items-center justify-between px-2">
+            <div className="flex h-full w-full flex-col">
+                <div className="flex w-full flex-row">
+                    <div className="ml-auto">
                         <form onSubmit={handleSearchSubmit}>
                             <SearchInput
                                 placeholder="Search team"
@@ -88,22 +101,34 @@ const TeamsListPage = (): JSX.Element => {
                         </form>
                     </div>
                 </div>
-                {isSearchResult && (
-                    <div className="px-3">
-                        {pageInfo.total} {pageInfo.total === 1 ? 'result' : 'results'} for{' '}
-                        {`"${term}"`}
-                    </div>
-                )}
+                {isSearchResult && renderSearchResultHeader()}
                 {teams?.length !== 0 ? (
-                    <div className="mt-4 flex h-full w-full flex-col justify-between gap-5">
-                        <div className="grid w-full grid-cols-2 gap-y-5 gap-x-10 px-3">
+                    <div className="mt-6 flex h-full w-full flex-col justify-between">
+                        <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2 2xl:grid-cols-3">
                             {teams?.map((team: TeamType) => (
                                 <Link key={team.id} href={`teams/${team.slug}`}>
-                                    <Card
-                                        header={team.name}
-                                        footer={`${team.members_count} members`}
-                                    >
-                                        {team.description}
+                                    <Card className="h-48 justify-end">
+                                        <CardHeader
+                                            floated={false}
+                                            color="transparent"
+                                            shadow={false}
+                                            className="mx-6 rounded-none"
+                                        >
+                                            <Typography variant="h5" className="text-gray-800">
+                                                {team.name}
+                                            </Typography>
+                                        </CardHeader>
+                                        <CardBody className="items-center pt-1">
+                                            <div className="leading-tight text-gray-600 line-clamp-3">
+                                                {team.description}
+                                            </div>
+                                        </CardBody>
+                                        <CardFooter className="flex self-center py-4 text-sm text-gray-500">
+                                            <div className="flex gap-2">
+                                                <BsPeopleFill className="text-xl" />
+                                                {team.members_count}
+                                            </div>
+                                        </CardFooter>
                                     </Card>
                                 </Link>
                             ))}

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -5,7 +5,7 @@ import type { PaginatorInfo } from '@/components/templates/QuestionsPageLayout'
 import GET_TEAMS from '@/helpers/graphql/queries/get_teams'
 import { errorNotify } from '@/helpers/toast'
 import { useQuery } from '@apollo/client'
-import { Card, CardBody, CardFooter, CardHeader, Typography } from '@material-tailwind/react'
+import { Card, CardBody, CardFooter, Typography } from '@material-tailwind/react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -107,25 +107,22 @@ const TeamsListPage = (): JSX.Element => {
                         <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2 2xl:grid-cols-3">
                             {teams?.map((team: TeamType) => (
                                 <Link key={team.id} href={`teams/${team.slug}`}>
-                                    <Card className="h-48 justify-end">
-                                        <CardHeader
-                                            floated={false}
-                                            color="transparent"
-                                            shadow={false}
-                                            className="mx-6 rounded-none"
-                                        >
-                                            <Typography variant="h5" className="text-gray-800">
+                                    <Card className="h-48 justify-between">
+                                        <CardBody className="justify-content-end items-center">
+                                            <Typography
+                                                variant="h5"
+                                                className="truncate text-gray-800"
+                                                title={`${team.name}`}
+                                            >
                                                 {team.name}
                                             </Typography>
-                                        </CardHeader>
-                                        <CardBody className="items-center pt-1">
-                                            <div className="leading-tight text-gray-600 line-clamp-3">
+                                            <div className="mt-2 leading-tight text-gray-600 line-clamp-3">
                                                 {team.description}
                                             </div>
                                         </CardBody>
-                                        <CardFooter className="flex self-center py-4 text-sm text-gray-500">
-                                            <div className="flex gap-2">
-                                                <BsPeopleFill className="text-xl" />
+                                        <CardFooter className="py-3 text-sm text-gray-500">
+                                            <div className="flex justify-center gap-2">
+                                                <BsPeopleFill className="text-base" />
                                                 {team.members_count}
                                             </div>
                                         </CardFooter>

--- a/frontend/pages/teams/index.tsx
+++ b/frontend/pages/teams/index.tsx
@@ -99,9 +99,9 @@ const TeamsListPage = (): JSX.Element => {
                                 onChange={onChange}
                             />
                         </form>
+                        {isSearchResult && renderSearchResultHeader()}
                     </div>
                 </div>
-                {isSearchResult && renderSearchResultHeader()}
                 {teams?.length !== 0 ? (
                     <div className="mt-6 flex h-full w-full flex-col justify-between">
                         <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2 2xl:grid-cols-3">


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-399

## Commands
none

## Pre-conditions
You must belong to at least one team.

## Expected Output

- [x] You should see the new design for Teams Page.

## Notes
- Also updated the Teams sidebar to show member avatars instead of static images.

## Screenshots
![image](https://user-images.githubusercontent.com/116238730/229702976-54339f0b-830b-499d-a0a5-d176074fe8c3.png)
![image](https://user-images.githubusercontent.com/116238730/229703065-296a4c34-137c-48c2-9d9e-d7c95f0e12d0.png)

