### PR TITLE
[Overflow-447] [BUGFIX] Truncate Tag Title in Tags Page Card

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateTag.php
+++ b/backend/app/GraphQL/Mutations/CreateTag.php
@@ -13,6 +13,10 @@ final class CreateTag
      */
     public function __invoke($_, array $args)
     {
+        if (strlen($args['name']) > 30) {
+            throw new CustomException('Please limit the title to less than 30 characters');
+        }
+
         if (Tag::where('name', $args['name'])->exists()) {
             throw new CustomException('Tag already exists.');
         }

--- a/backend/app/GraphQL/Mutations/UpdateTag.php
+++ b/backend/app/GraphQL/Mutations/UpdateTag.php
@@ -15,6 +15,10 @@ final class UpdateTag
      */
     public function __invoke($_, array $args)
     {
+        if (strlen($args['name']) > 30) {
+            throw new CustomException('Please limit the title to less than 30 characters');
+        }
+
         try {
             $tag = Tag::findOrFail($args['id']);
 

--- a/backend/app/GraphQL/Mutations/UpdateTag.php
+++ b/backend/app/GraphQL/Mutations/UpdateTag.php
@@ -18,6 +18,10 @@ final class UpdateTag
         if (strlen($args['name']) > 30) {
             throw new CustomException('Please limit the title to less than 30 characters');
         }
+        
+        if (strlen($args['description']) > 250) {
+            throw new CustomException('Please limit the description to less than 250 characters');
+        }
 
         try {
             $tag = Tag::findOrFail($args['id']);

--- a/frontend/components/molecules/Pill/index.tsx
+++ b/frontend/components/molecules/Pill/index.tsx
@@ -27,11 +27,11 @@ const Pill = ({ tag }: PillProps): JSX.Element => {
             }}
         >
             <PopoverHandler>
-                <div className="flex min-w-fit cursor-pointer flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal !outline-none">
+                <div className="flex min-w-fit cursor-pointer flex-row items-center gap-1 rounded-full bg-red-300 py-1 px-3 text-xs font-normal text-gray-900 !outline-none">
                     {watchedTags.some((tempTag) => tempTag.name === tag.name) && (
                         <Icons name="pill_eye" />
                     )}
-                    <span className="line-clamp-1" title={tag.name}>
+                    <span className="text-gray-900 line-clamp-1" title={tag.name}>
                         {tag.name}
                     </span>
                 </div>

--- a/frontend/components/molecules/Pill/index.tsx
+++ b/frontend/components/molecules/Pill/index.tsx
@@ -31,7 +31,9 @@ const Pill = ({ tag }: PillProps): JSX.Element => {
                     {watchedTags.some((tempTag) => tempTag.name === tag.name) && (
                         <Icons name="pill_eye" />
                     )}
-                    <span>{tag.name}</span>
+                    <span className="line-clamp-1" title={tag.name}>
+                        {tag.name}
+                    </span>
                 </div>
             </PopoverHandler>
             <PopoverContent className="max-w-[22rem] bg-gray-200">

--- a/frontend/pages/tags/index.tsx
+++ b/frontend/pages/tags/index.tsx
@@ -1,3 +1,4 @@
+import Pill from '@/components/molecules/Pill'
 import SearchInput from '@/components/molecules/SearchInput'
 import SortDropdown from '@/components/molecules/SortDropdown'
 import Paginate from '@/components/organisms/Paginate'
@@ -155,15 +156,15 @@ const TagsListPage = (): JSX.Element => {
                             return (
                                 <Link key={tag.id} href={`questions/tagged/${tag.slug}`}>
                                     <Card className="h-52 justify-between">
-                                        <CardBody className="">
-                                            <p title={tag.name}>
-                                                <Typography
-                                                    variant="h5"
-                                                    className="mb-2 line-clamp-1"
-                                                >
-                                                    {tag.name}
-                                                </Typography>
-                                            </p>
+                                        <CardBody>
+                                            <div
+                                                className="mb-3 w-fit"
+                                                onClick={(event) => {
+                                                    event.preventDefault()
+                                                }}
+                                            >
+                                                <Pill tag={tag} />
+                                            </div>
                                             <Typography className="line-clamp-3">
                                                 {tag.description}
                                             </Typography>

--- a/frontend/pages/tags/index.tsx
+++ b/frontend/pages/tags/index.tsx
@@ -156,9 +156,14 @@ const TagsListPage = (): JSX.Element => {
                                 <Link key={tag.id} href={`questions/tagged/${tag.slug}`}>
                                     <Card className="h-52 justify-between">
                                         <CardBody className="">
-                                            <Typography variant="h5" className="mb-2">
-                                                {tag.name}
-                                            </Typography>
+                                            <p title={tag.name}>
+                                                <Typography
+                                                    variant="h5"
+                                                    className="mb-2 line-clamp-1"
+                                                >
+                                                    {tag.name}
+                                                </Typography>
+                                            </p>
                                             <Typography className="line-clamp-3">
                                                 {tag.description}
                                             </Typography>


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-447

## Commands
Go to `Tags` page

## Pre-conditions

## Expected Output
- [x] The title should be truncated if it's too long
- [x] The full title will be displayed on hover
- [x] The title should be less than 30 characters when creating a new tag 

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/111732984/231363238-f26939f8-197c-4dea-a5d0-3854c83c7bb3.png)
![image](https://user-images.githubusercontent.com/111732984/231136341-287f2e41-fd9f-4cc5-85de-6d1d9dfe7c1e.png)
