### PR TITLE
[Overflow-442] [BUGFIX] Disable hover effect on selected menu

### DIFF
--- a/frontend/components/molecules/SidebarButton/index.tsx
+++ b/frontend/components/molecules/SidebarButton/index.tsx
@@ -35,7 +35,7 @@ const SidebarButton = ({ IconName, Text, subMenu, url }: SidebarButtonProps): an
                     {({ open }) => (
                         <>
                             <Disclosure.Button
-                                className={`flex items-center space-x-2 py-2.5 pl-7 text-xl font-normal `}
+                                className={`flex w-full items-center space-x-2 py-2.5 pl-7 text-xl font-normal`}
                             >
                                 <SidebarIcon name={IconName} />
                                 <span className="pl-2">{Text}</span>
@@ -53,8 +53,8 @@ const SidebarButton = ({ IconName, Text, subMenu, url }: SidebarButtonProps): an
                                                     className={`flex items-center space-x-2 py-2.5 pl-16 text-xl font-normal ${
                                                         isSelected(2, child.url)
                                                             ? selectedClass
-                                                            : ''
-                                                    } hover:bg-red-200 hover:text-white active:text-primary-red`}
+                                                            : 'hover:bg-red-200'
+                                                    }`}
                                                 >
                                                     <SidebarIcon name={child.IconName} />
                                                     <span className="pl-2">{child.Text}</span>
@@ -71,8 +71,8 @@ const SidebarButton = ({ IconName, Text, subMenu, url }: SidebarButtonProps): an
                 <Link
                     href={url}
                     className={`flex items-center space-x-2 py-2.5 pl-7 text-xl font-normal ${
-                        isSelected(1, url) ? selectedClass : ''
-                    } hover:bg-red-200 hover:text-white active:text-primary-red`}
+                        isSelected(1, url) ? selectedClass : 'hover:bg-red-200 '
+                    }`}
                 >
                     <SidebarIcon name={IconName} />
                     <span className="pl-2">{Text}</span>


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-442

## Commands
none

## Pre-conditions
none

## Expected Output

- [x] There is no hover effect on the selected item in the sidebar.

## Notes

## Screenshots
[Screencast 2023-04-11 17-55-27.webm](https://user-images.githubusercontent.com/116238730/231127342-be015906-2cc7-458b-a7b3-faf1702751be.webm)
