### PR TITLE
[Overflow-445] [BUGFIX] Truncate Profile Name in Profile Dropdown

### DIFF
--- a/backend/app/GraphQL/Mutations/UpdateUser.php
+++ b/backend/app/GraphQL/Mutations/UpdateUser.php
@@ -2,6 +2,7 @@
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\CustomException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\URL;
 
@@ -33,6 +34,14 @@ final class UpdateUser
     public function __invoke($_, array $args)
     {
         $user = Auth::user();
+
+        if (strlen($args['first_name']) > 30) {
+            throw new CustomException('Please limit the first name to less than 30 characters');
+        }
+
+        if (strlen($args['last_name']) > 30) {
+            throw new CustomException('Please limit the last name to less than 30 characters');
+        }
 
         $user->update([
             'first_name' => $args['first_name'],

--- a/frontend/components/molecules/UserDropdown/index.tsx
+++ b/frontend/components/molecules/UserDropdown/index.tsx
@@ -53,9 +53,12 @@ const UserDropdown = ({
                 leaveTo="transform opacity-0 scale-95"
             >
                 <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-                    <div className="py-1 ">
+                    <div className="py-3">
                         <Menu.Item>
-                            <span className="block px-4 py-2 text-sm font-bold text-gray-900 line-clamp-1">
+                            <span
+                                className="px-4 text-sm font-bold text-gray-900 line-clamp-1"
+                                title={`${first_name} ${last_name}`}
+                            >
                                 {`${first_name} ${last_name}`}
                             </span>
                         </Menu.Item>

--- a/frontend/components/organisms/ProfileInfo/edit.tsx
+++ b/frontend/components/organisms/ProfileInfo/edit.tsx
@@ -3,11 +3,11 @@ import Icons from '@/components/atoms/Icons'
 import RichTextEditor from '@/components/molecules/RichTextEditor'
 import UPDATE_USER from '@/helpers/graphql/mutations/update_user'
 import { errorNotify, successNotify } from '@/helpers/toast'
+import type { ProfileType } from '@/pages/users/[slug]'
+import { useMutation } from '@apollo/client'
+import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { useRouter } from 'next/router'
-import { useMutation } from '@apollo/client'
-import type { ProfileType } from '@/pages/users/[slug]'
 
 type Props = {
     user_id: number
@@ -112,7 +112,9 @@ const ProfileInfoEdit = ({
                 }, 3000)
             })
             .catch((e) => {
-                errorNotify('Please Complete the Input Fields!')
+                if (e.message === 'Internal server error')
+                    errorNotify('Please complete the input fields!')
+                else errorNotify(e.message)
             })
     }
 


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-445

## Commands
Click the dropdown in the navbar

## Pre-conditions

## Expected Output
- [x] Long profile names should be truncated in the User Dropdown
- [x] The complete name should be shown as tooltip when hovering

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/111732984/231361652-92469bea-89fe-457e-9bb0-4770871894e2.png)
