### PR TITLE
[Overflow-358] [BE] Create API for retrieving user's questions

### DIFF
--- a/backend/app/GraphQL/Queries/Questions.php
+++ b/backend/app/GraphQL/Queries/Questions.php
@@ -37,6 +37,10 @@ final class Questions
                 $query->where('user_id', $args['user_id'])->get();
             }
 
+            if (isset($args['user_slug'])) {
+                $query->whereRelation('user', 'slug', $args['user_slug']);
+            }
+
             if (isset($args['tag']) && $args['tag']) {
                 $query->whereHas('tags', function ($tags) use ($args) {
                     $tags->where('slug', $args['tag']);

--- a/backend/graphql/question/query.graphql
+++ b/backend/graphql/question/query.graphql
@@ -5,6 +5,7 @@ input filter {
     team: String
     is_public: Boolean
     user_id: ID
+    user_slug: String
 }
 
 enum ORDERBY {


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-358

## Commands
```
query Questions {
  questions(
    filter: {user_slug: "slug"},
  	first: 5,
    orderBy: [{column: CREATED_AT, order: DESC}],
    page: 1
  ) {
    paginatorInfo {
      currentPage
    }
    data {
      id
      title
      content
      created_at
      user {
        id
        slug
      }
    }
  }
}
```

## Pre-conditions
none

## Expected Output

- [x] You can retrieve a user's questions by their slug.

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/116238730/231373414-f7dee972-496f-4c7d-b247-daa4702909b5.png)
