### PR TITLE
[Overflow-360] [BE] Create API for retrieving user's teams

### DIFF
--- a/backend/app/GraphQL/Mutations/UpdateTag.php
+++ b/backend/app/GraphQL/Mutations/UpdateTag.php
@@ -18,7 +18,7 @@ final class UpdateTag
         if (strlen($args['name']) > 30) {
             throw new CustomException('Please limit the title to less than 30 characters');
         }
-        
+
         if (strlen($args['description']) > 250) {
             throw new CustomException('Please limit the description to less than 250 characters');
         }

--- a/backend/app/GraphQL/Queries/Teams.php
+++ b/backend/app/GraphQL/Queries/Teams.php
@@ -19,6 +19,14 @@ final class Teams
             return $query;
         }
 
+        if (isset($args['user_slug'])) {
+            $user_slug = $args['user_slug'];
+
+            return $query->whereHas('members', function ($queryMembers) use ($user_slug) {
+                $queryMembers->whereRelation('user', 'slug', $user_slug);
+            });
+        }
+
         $user_id = Auth::id();
 
         $query->where('user_id', $user_id);

--- a/backend/graphql/team/query.graphql
+++ b/backend/graphql/team/query.graphql
@@ -6,6 +6,7 @@ extend type Query {
     getUserTeams(
         name: String! = "%%" @where(operator: "like")
         isAdmin: Boolean = false
+        user_slug: String
     ): [Team!]!
         @guard(with: ["api"])
         @paginate(builder: "App\\GraphQL\\Queries\\Teams")


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-360

## Commands

```
query getTeams {
  getUserTeams(first: 10, user_slug: "slug") {
    data {
      id
      name
    } 
    paginatorInfo {
      currentPage
      hasMorePages
      total
    }
  }
}
```

## Pre-conditions
none

## Expected Output

- [x] You can retrieve a user's teams by the user's slug.

## Notes

## Screenshots
![image](https://user-images.githubusercontent.com/116238730/231641599-9cc67f56-a891-430f-8efa-b26d4d7ee13b.png)
