### PR TITLE
[Overflow-361] [FE] Implement API to User Detail Page for Admin

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateTeam.php
+++ b/backend/app/GraphQL/Mutations/CreateTeam.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Mutations;
 
 use App\Exceptions\CustomException;
+use App\Models\Member;
 use App\Models\Team;
 use App\Models\User;
 use Exception;
@@ -23,6 +24,12 @@ final class CreateTeam
                 'name' => $args['name'],
                 'description' => $args['description'],
                 'user_id' => $user->id,
+            ]);
+
+            Member::create([
+                'user_id' => $user->id,
+                'team_role_id' => 1,
+                'team_id' => $team->id,
             ]);
 
             return $team;

--- a/backend/app/GraphQL/Queries/Questions.php
+++ b/backend/app/GraphQL/Queries/Questions.php
@@ -55,7 +55,7 @@ final class Questions
                 if (isset($args['is_public'])) {
                     $query->where('is_public', $args['is_public']);
                 }
-            } else {
+            } elseif (! $args['isAdmin']) {
                 $query->where('is_public', true);
             }
 

--- a/backend/app/Models/Answer.php
+++ b/backend/app/Models/Answer.php
@@ -13,7 +13,7 @@ class Answer extends Model
     protected $guarded = [];
 
     protected $appends = ['vote_count', 'humanized_created_at', 'is_created_by_user',
-         'user_vote', 'is_from_user' , 'upvote_percentage'];
+        'user_vote', 'is_from_user', 'upvote_percentage'];
 
     public function user()
     {

--- a/backend/app/Models/Question.php
+++ b/backend/app/Models/Question.php
@@ -84,11 +84,6 @@ class Question extends Model
         return $this->votes()->sum('value');
     }
 
-    public function getUserVoteAttribute()
-    {
-        return $this->votes()->where('user_id', auth()->id())->first()->value ?? 0;
-    }
-
     public function getUpvotePercentageAttribute()
     {
         $totalVotes = $this->votes()->count();
@@ -97,6 +92,11 @@ class Question extends Model
         }
 
         return 0;
+    }
+
+    public function getUserVoteAttribute()
+    {
+        return $this->votes()->where('user_id', auth()->id())->first()->value ?? 0;
     }
 
     public function getHumanizedCreatedAtAttribute()

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -26,7 +26,7 @@ class User extends Authenticatable
     protected $appends = [
         'question_count', 'answer_count', 'top_questions', 'top_answers',
         'is_following', 'follower_count', 'following_count', 'bookmarked_questions',
-        'bookmarked_answers'
+        'bookmarked_answers',
     ];
 
     /**
@@ -183,6 +183,7 @@ class User extends Authenticatable
     {
         return $this->bookmarks()->where('bookmarkable_type', Question::class)->get();
     }
+
     public function getBookmarkedAnswersAttribute()
     {
         return $this->bookmarks()->where('bookmarkable_type', Answer::class)->get();

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -162,7 +162,11 @@ class User extends Authenticatable
 
     public function getIsFollowingAttribute()
     {
-        return Auth::user()->following()->where('following_id', $this->id)->exists();
+        if (Auth::user()) {
+            return Auth::user()->following()->where('following_id', $this->id)->exists();
+        } else {
+            return false;
+        }
     }
 
     public function getFollowerCountAttribute()

--- a/backend/graphql/answer/query.graphql
+++ b/backend/graphql/answer/query.graphql
@@ -4,7 +4,10 @@ input answerFilter {
 
 extend type Query {
     answer(id: ID! @eq): Answer @guard(with: ["api"]) @find
-    answers(filter: answerFilter @spread): [Answer!]!
+    answers(
+        orderBy: _ @orderBy(columns: ["created_at", "updated_at"])
+        filter: answerFilter @spread
+    ): [Answer!]!
         @guard(with: ["api"])
         @paginate(builder: "App\\GraphQL\\Queries\\Answers")
 }

--- a/backend/graphql/answer/type.graphql
+++ b/backend/graphql/answer/type.graphql
@@ -6,6 +6,7 @@ type Answer {
     updated_at: String
     humanized_created_at: String
     vote_count: Int
+    upvote_percentage: Float
     user_vote: Int
     is_bookmarked: Boolean
     user: User! @belongsTo

--- a/backend/graphql/question/query.graphql
+++ b/backend/graphql/question/query.graphql
@@ -31,6 +31,7 @@ extend type Query {
     ): Question @guard(with: ["api"])
     questions(
         orderBy: _ @orderBy(columns: ["created_at", "updated_at"])
+        isAdmin: Boolean = false
         filter: filter @spread
     ): [Question!]!
         @guard(with: ["api"])

--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -59,7 +59,7 @@ const getButtonClasses = (usage: string, size: string): string => {
         case 'icon':
             return 'absolute inset-y-0 right-0 mr-2 flex items-center'
         case 'popover':
-            return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 bg-white border-red-500 focus:ring-red-600 hover:bg-light-red'
+            return 'rounded-[5px] h-[28px] border-2 px-4 text-[12px] text-neutral-900 bg-white border-neutral-900 border-[1px] hover:bg-neutral-200 outline-none'
         case 'cancel-item':
             return 'items-center rounded-full border-2 outline-0 border-primary-red absolute outline-primary-red -top-2 -right-2 bg-white text-primary-red p-1 hover:bg-primary-red hover:text-white active:bg-primary-red active:text-white active:outline active:outline-[2px]'
         case 'edit-top-right':

--- a/frontend/components/molecules/DropdownFilters/index.tsx
+++ b/frontend/components/molecules/DropdownFilters/index.tsx
@@ -1,7 +1,9 @@
+import { CustomIcons } from '@/components/atoms/Icons'
 import { useRouter } from 'next/router'
 import SortDropdown from '../SortDropdown'
 
 type TriggerType = 'DATE' | 'ANSWER'
+const { DotsIcon } = CustomIcons
 
 type FilterType = {
     state: string
@@ -106,11 +108,18 @@ const DropdownFilters = ({ triggers }: Props): JSX.Element => {
     }
 
     return (
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row gap-1">
             {triggers.map((trigger, index) => {
                 return (
-                    <div key={index} className="min-w-[8rem]">
+                    <div key={index}>
                         <SortDropdown
+                            icon={
+                                trigger === 'ANSWER' ? (
+                                    <div className="m-auto">
+                                        <DotsIcon />
+                                    </div>
+                                ) : null
+                            }
                             filters={filterLists[trigger].filters}
                             selectedFilter={filterLists[trigger].state}
                         />

--- a/frontend/components/molecules/Pill/index.tsx
+++ b/frontend/components/molecules/Pill/index.tsx
@@ -1,7 +1,7 @@
 import Icons from '@/components/atoms/Icons'
 import { useBoundStore } from '@/helpers/store'
 import { Popover, PopoverContent, PopoverHandler } from '@material-tailwind/react'
-import Tooltips from '../Tooltip'
+import Tooltips from '../TagPopover'
 
 type PillProps = {
     tag: {

--- a/frontend/components/molecules/Privacy/index.tsx
+++ b/frontend/components/molecules/Privacy/index.tsx
@@ -9,7 +9,7 @@ type PrivacyProps = {
 
 const Privacy = ({ name, additionalClass = '' }: PrivacyProps): JSX.Element => {
     return (
-        <div className={`flex items-center gap-1 text-sm font-semibold ${additionalClass}`}>
+        <div className={`flex items-center gap-1 text-xs font-semibold ${additionalClass}`}>
             <span>{name}</span>
             <div>{name === 'Public' ? <UnlockIcon /> : <LockIcon />}</div>
         </div>

--- a/frontend/components/molecules/ProfileCard/index.tsx
+++ b/frontend/components/molecules/ProfileCard/index.tsx
@@ -23,6 +23,7 @@ export type ProfileCardProps = {
     handleEditModal?: (input: boolean) => void
     id: number
     isPublic: boolean
+    isAdmin?: boolean
 }
 
 const ProfileCard = ({
@@ -40,6 +41,7 @@ const ProfileCard = ({
     is_following,
     role,
     isPublic,
+    isAdmin = false,
     toggleFollow,
     handleFollower,
     handleFollowing,
@@ -73,9 +75,6 @@ const ProfileCard = ({
                             <div className="flex flex-row items-center justify-between">
                                 <div className="text-sm font-bold leading-[120%]">{`${first_name} ${last_name}`}</div>
                                 {!isPublic && (
-                                    // <EditProfileModal
-                                    //     {...{ first_name, last_name, about_me, avatar, updated_at }}
-                                    // />
                                     <div
                                         className="h-4 cursor-pointer text-xs font-semibold leading-[120%] text-neutral-900 hover:underline"
                                         onClick={() => {
@@ -122,7 +121,7 @@ const ProfileCard = ({
                                 <span className="font-bold">{follower_count}</span> Followers
                             </div>
                         </div>
-                        {isPublic && (
+                        {!isAdmin && isPublic && (
                             <div className="w-[187px]">
                                 <Button usage="main-follow" onClick={onClickFollow}>
                                     {is_following ? 'Unfollow' : 'Follow'}

--- a/frontend/components/molecules/SortDropdown/index.tsx
+++ b/frontend/components/molecules/SortDropdown/index.tsx
@@ -1,15 +1,23 @@
+import { CustomIcons } from '@/components/atoms/Icons'
 import type { FilterType } from '@/components/templates/QuestionsPageLayout'
 import { Menu, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
-import { HiChevronDown } from 'react-icons/hi'
+
+const { ChevronIcon } = CustomIcons
 
 type AppProps = {
     grouped?: boolean
     selectedFilter: string
+    icon?: React.ReactNode
     filters: FilterType[] | FilterType[][]
 }
 
-const SortDropdown = ({ grouped = false, selectedFilter, filters }: AppProps): JSX.Element => {
+const SortDropdown = ({
+    grouped = false,
+    selectedFilter,
+    icon,
+    filters,
+}: AppProps): JSX.Element => {
     const renderFilters = (): JSX.Element[] => {
         return filters.map((filter) => {
             const newFilter = filter as FilterType
@@ -19,7 +27,7 @@ const SortDropdown = ({ grouped = false, selectedFilter, filters }: AppProps): J
                         {({ active }) => (
                             <div
                                 className={`${
-                                    active ? 'bg-light-red' : 'bg-white-100'
+                                    active ? 'bg-primary-200' : 'bg-white-100'
                                 } w-full py-2 px-4 text-sm text-primary-black`}
                                 onClick={newFilter.onClick}
                             >
@@ -59,14 +67,18 @@ const SortDropdown = ({ grouped = false, selectedFilter, filters }: AppProps): J
     }
 
     return (
-        <div className="flex items-center">
+        <div className="flex items-center ">
             <Menu as="div" className="relative inline-block w-full text-left">
                 <div>
-                    <Menu.Button className="inline-flex items-center justify-center rounded-md bg-primary-red p-2 text-center text-sm text-white hover:bg-dark-red focus:outline-none focus:ring-1 focus:ring-red-700">
-                        <span className="px-2">{selectedFilter}</span>
-                        <div className="items-end items-center">
-                            <HiChevronDown className="text-red text-lg" />
-                        </div>
+                    <Menu.Button className="flex justify-end rounded-[5px] border border-neutral-500 p-2 text-sm text-neutral-900">
+                        <span className="">{selectedFilter}</span>
+                        {!icon ? (
+                            <div className="m-auto">
+                                <ChevronIcon />
+                            </div>
+                        ) : (
+                            icon
+                        )}
                     </Menu.Button>
                 </div>
                 <Transition
@@ -78,7 +90,7 @@ const SortDropdown = ({ grouped = false, selectedFilter, filters }: AppProps): J
                     leaveFrom="transform opacity-100 scale-100"
                     leaveTo="transform opacity-0 scale-95"
                 >
-                    <Menu.Items className="absolute left-0 z-10 mt-1 w-44 divide-y divide-gray-200 rounded-lg bg-white bg-white shadow">
+                    <Menu.Items className="absolute left-0 z-10 mt-1 w-44 divide-y divide-neutral-200 rounded-[5px] border border-neutral-200 bg-white shadow">
                         {grouped ? renderGroupedFilters() : renderFilters()}
                     </Menu.Items>
                 </Transition>

--- a/frontend/components/molecules/Tag/index.tsx
+++ b/frontend/components/molecules/Tag/index.tsx
@@ -1,7 +1,7 @@
 import { CustomIcons } from '@/components/atoms/Icons'
 import type { TagType } from '@/pages/questions/[slug]'
-import { useRouter } from 'next/router'
-import React from 'react'
+import { Popover, PopoverContent, PopoverHandler } from '@material-tailwind/react'
+import TagPopover from '../TagPopover'
 
 const { EyeIcon } = CustomIcons
 
@@ -10,28 +10,30 @@ type TagProps = {
 }
 
 const Tag = ({ tag }: TagProps): JSX.Element => {
-    const router = useRouter()
-
-    const handleRedirect = async (e: React.MouseEvent): Promise<void> => {
-        e.stopPropagation()
-        await router.push(`/questions/tagged/${tag.slug}`)
-    }
     return (
-        <div
-            className="flex h-4 cursor-pointer items-center gap-[2px] rounded-xl bg-neutral-200 px-1 py-[2px] text-[10px]"
-            onClick={async (e) => {
-                await handleRedirect(e)
+        <Popover
+            placement="bottom-start"
+            animate={{
+                mount: { scale: 1, y: 0 },
+                unmount: { scale: 0, y: 25 },
             }}
         >
-            {tag.is_watched_by_user && (
-                <div className="">
-                    <EyeIcon />
+            <PopoverHandler>
+                <div className="flex h-4 cursor-pointer items-center gap-[2px] rounded-xl bg-neutral-200 px-1 py-[2px] text-[10px]">
+                    {tag.is_watched_by_user && (
+                        <div>
+                            <EyeIcon />
+                        </div>
+                    )}
+                    <span className="text-neutral-900" title={tag.name}>
+                        {tag.name}
+                    </span>
                 </div>
-            )}
-            <span className="text-neutral-900" title={tag.name}>
-                {tag.name}
-            </span>
-        </div>
+            </PopoverHandler>
+            <PopoverContent className="z-20 rounded-[5px] border-neutral-200 bg-neutral-100 px-0 py-2">
+                <TagPopover tag={tag} />
+            </PopoverContent>
+        </Popover>
     )
 }
 

--- a/frontend/components/molecules/TagPopover/index.tsx
+++ b/frontend/components/molecules/TagPopover/index.tsx
@@ -1,10 +1,13 @@
 import Button from '@/components/atoms/Button'
 import { ADD_WATCHED_TAG, REMOVE_WATCHED_TAG } from '@/helpers/graphql/mutations/sidebar'
+import GET_ANSWERS from '@/helpers/graphql/queries/get_answers'
+import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
 import { QTagsSidebar } from '@/helpers/graphql/queries/sidebar'
 import { useBoundStore } from '@/helpers/store'
 import { errorNotify, successNotify } from '@/helpers/toast'
+import { type Tab } from '@/pages/manage/users/[slug]'
 import { useMutation } from '@apollo/client'
-import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 type TagType = {
     tag: {
@@ -18,9 +21,21 @@ type TagType = {
     }
 }
 
-const Tooltips = ({ tag }: TagType): JSX.Element => {
+const TagPopover = ({ tag }: TagType): JSX.Element => {
+    const router = useRouter()
+    const manageUsersSelectedTab = (router.query.tab ?? 'Questions') as Tab
     const [addWatchedTagAPI] = useMutation(ADD_WATCHED_TAG, {
-        refetchQueries: [{ query: QTagsSidebar }],
+        refetchQueries: [
+            { query: QTagsSidebar },
+            {
+                query: manageUsersSelectedTab === 'Questions' ? GET_QUESTIONS : GET_ANSWERS,
+                variables: {
+                    first: 5,
+                    page: 1,
+                    filter: { user_slug: router.query.slug as string },
+                },
+            },
+        ],
         onCompleted: (data) => {
             if (data.addWatchedTag === 'Successfully added the tag') {
                 successNotify(data.addWatchedTag)
@@ -30,7 +45,17 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
         },
     })
     const [removeWatchedTagAPI] = useMutation(REMOVE_WATCHED_TAG, {
-        refetchQueries: [{ query: QTagsSidebar }],
+        refetchQueries: [
+            { query: QTagsSidebar },
+            {
+                query: manageUsersSelectedTab === 'Questions' ? GET_QUESTIONS : GET_ANSWERS,
+                variables: {
+                    first: 5,
+                    page: 1,
+                    filter: { user_slug: router.query.slug as string },
+                },
+            },
+        ],
 
         onCompleted: (data) => {
             if (data.removeWatchedTag === 'Successfully removed tag from WatchList') {
@@ -48,31 +73,20 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
         if (isWatched) await removeWatchedTagAPI({ variables: { tagId: tag.id } })
         else await addWatchedTagAPI({ variables: { tagId: tag.id } })
     }
-
     return (
-        <div className="cursor-default font-normal">
-            <div className="flex items-center">
-                <span className="mr-20 text-red-700">
-                    {tag.count_watching_users}{' '}
-                    {(tag.count_watching_users as number) !== 1 ? `Watchers` : `Watcher`}
-                </span>
-                <span className="mr-2">
-                    {tag.count_tagged_questions}{' '}
-                    {(tag.count_tagged_questions as number) !== 1 ? `Questions` : `Question`}
-                </span>
+        <div className="flex min-h-[88px] w-72 flex-col gap-2">
+            <div className="border-b border-neutral-300 px-2 pb-2">
+                <span className="text-[12px] text-neutral-900">{tag.description}</span>
             </div>
-            <div className="py-2">
-                <span>
-                    {tag.description}
-                    <Link
-                        href={`/questions/tagged/${tag.slug ?? ''}`}
-                        className="ml-2 text-blue-500 underline hover:text-blue-400"
-                    >
-                        View Tag
-                    </Link>
-                </span>
-            </div>
-            <div className="float-right p-2">
+            <div className="flex items-center justify-center gap-2">
+                <Button
+                    usage="popover"
+                    onClick={() => {
+                        void router.push(`/questions/tagged/${tag.slug ?? ''}`)
+                    }}
+                >
+                    View tag
+                </Button>
                 <Button
                     usage="popover"
                     type="submit"
@@ -80,11 +94,11 @@ const Tooltips = ({ tag }: TagType): JSX.Element => {
                         await toggleTagWatch()
                     }}
                 >
-                    {`${isWatched ? 'Unwatch' : 'Watch'} Tag`}
+                    {`${isWatched ? 'Unwatch' : 'Watch'}`}
                 </Button>
             </div>
         </div>
     )
 }
 
-export default Tooltips
+export default TagPopover

--- a/frontend/components/molecules/TeamCard/index.tsx
+++ b/frontend/components/molecules/TeamCard/index.tsx
@@ -1,27 +1,33 @@
 import { CustomIcons } from '@/components/atoms/Icons'
+import Link from 'next/link'
 
 const { UsersIcon } = CustomIcons
 
 type TeamCardProps = {
+    slug: string
     name: string
     description: string
     usersCount: number
 }
 
-const TeamCard = ({ name, description, usersCount }: TeamCardProps): JSX.Element => {
+const TeamCard = ({ slug, name, description, usersCount }: TeamCardProps): JSX.Element => {
     return (
-        <div className="flex h-[200px] flex-col rounded-[5px] border border-neutral-200 text-neutral-900">
-            <div className="bg-primary-200 p-2 text-center text-base font-semibold">{name}</div>
-            <div className="flex h-full flex-col items-center justify-between p-4">
-                <p className="px-4 line-clamp-3">{description}</p>
-                <div className="flex gap-1 text-neutral-disabled">
-                    <div className="m-auto">
-                        <UsersIcon />
+        <Link href={`/teams/${slug}`}>
+            <div className="group flex h-[200px] flex-col rounded-[5px] border border-neutral-200 text-neutral-900">
+                <div className="bg-primary-200 p-2 text-center text-sm font-semibold group-hover:text-primary-base">
+                    {name}
+                </div>
+                <div className="flex h-full flex-col items-center justify-between p-4">
+                    <p className="px-4 text-xs line-clamp-3">{description}</p>
+                    <div className="flex gap-[2px] text-neutral-disabled">
+                        <div>
+                            <UsersIcon />
+                        </div>
+                        <span className="text-xs">{usersCount}</span>
                     </div>
-                    <span>{usersCount}</span>
                 </div>
             </div>
-        </div>
+        </Link>
     )
 }
 

--- a/frontend/components/organisms/Paginate/index.tsx
+++ b/frontend/components/organisms/Paginate/index.tsx
@@ -8,9 +8,8 @@ import {
 } from 'react-icons/hi'
 
 type Props = {
-    currentPage: number
-    lastPage: number
-    hasMorePages: boolean
+    currentPage?: number
+    lastPage?: number
     perPage?: number
     onPageChange: (first: number, page: number) => void
 }
@@ -24,9 +23,8 @@ type PageItemType = {
 }
 
 const Paginate = ({
-    currentPage,
-    lastPage,
-    hasMorePages,
+    currentPage = 1,
+    lastPage = 1,
     perPage = 10,
     onPageChange,
 }: Props): JSX.Element => {

--- a/frontend/components/organisms/QuestionGridItem/index.tsx
+++ b/frontend/components/organisms/QuestionGridItem/index.tsx
@@ -12,8 +12,8 @@ type QuestionGridItemProps = {
     content: string
     voteCount: number
     upvotePercentage: number
-    answerCount: number
-    viewCount: number
+    answerCount?: number
+    viewCount?: number
     isPublic: boolean
     tags: TagType[]
     author: UserType
@@ -50,22 +50,32 @@ const QuestionGridItem = ({
                     <p className="break-all text-[12px] leading-4 line-clamp-3">
                         {parseHTML(content)}
                     </p>
-                    <div className="mt-auto flex w-fit gap-1 rounded-[4px] border border-primary-base px-1 py-[2px] text-primary-base">
-                        <div>
+                    <div className="mt-auto flex h-5 w-fit gap-[1px] rounded-[4px] border border-primary-base px-1 text-primary-base">
+                        <div className="m-auto">
                             <ThumbUpIcon />
                         </div>
-                        <span className="text-xs font-bold">{upvotePercentage.toFixed()}%</span>
+                        <span className="text-[10px] font-bold">{upvotePercentage.toFixed()}%</span>
                     </div>
                 </div>
-                <div className="flex min-w-fit flex-col items-end text-xs font-light">
-                    <span>{voteCount} Votes</span>
-                    <span>{answerCount} Answers</span>
-                    <span>{viewCount} Views</span>
+                <div className="flex min-w-fit flex-col items-end gap-1 text-xs font-light">
+                    <span>
+                        {voteCount} {voteCount === 1 ? 'Vote' : 'Votes'}
+                    </span>
+                    {answerCount !== undefined && (
+                        <span>
+                            {answerCount} {answerCount === 1 ? 'Answer' : 'Answers'}
+                        </span>
+                    )}
+                    {viewCount !== undefined && (
+                        <span>
+                            {viewCount} {viewCount === 1 ? 'View' : 'Views'}
+                        </span>
+                    )}
                 </div>
             </div>
             <div className="mt-auto flex flex-col gap-1">
                 <Tags values={tags} />
-                <div className="flex justify-between text-xs">
+                <div className="flex justify-between text-[10px]">
                     <span>
                         {`Author: `}
                         <Link href={`/users/${String(author.slug)}`} className="text-primary-blue">

--- a/frontend/components/organisms/QuestionGridItem/index.tsx
+++ b/frontend/components/organisms/QuestionGridItem/index.tsx
@@ -1,95 +1,78 @@
 import { CustomIcons } from '@/components/atoms/Icons'
 import Tags from '@/components/molecules/Tags'
+import { parseHTML } from '@/helpers/htmlParsing'
+import type { TagType, UserType } from '@/pages/questions/[slug]'
 import Link from 'next/link'
 
-const { UnlockIcon, ThumbUpIcon } = CustomIcons
+const { LockIcon, ThumbUpIcon, UnlockIcon } = CustomIcons
 
-const QuestionGridItem = (): JSX.Element => {
+type QuestionGridItemProps = {
+    slug: string
+    title: string
+    content: string
+    voteCount: number
+    upvotePercentage: number
+    answerCount: number
+    viewCount: number
+    isPublic: boolean
+    tags: TagType[]
+    author: UserType
+    createdAt: string
+}
+
+const QuestionGridItem = ({
+    slug,
+    title,
+    content,
+    voteCount,
+    upvotePercentage,
+    answerCount,
+    viewCount,
+    isPublic,
+    tags,
+    author,
+    createdAt,
+}: QuestionGridItemProps): JSX.Element => {
     return (
-        <div className="flex min-h-[176px] flex-col gap-4 rounded-[5px] border border-neutral-200 p-2 text-neutral-900">
+        <div className="flex min-h-[166px] flex-col gap-4 rounded-[5px] border border-neutral-200 p-2 text-neutral-900">
             <div className="flex justify-between">
-                <span className="text-base font-semibold">Title Content</span>
-                <div className="flex items-center">
-                    <UnlockIcon />
-                </div>
+                <span
+                    className="w-fit truncate text-sm font-semibold hover:text-primary-base"
+                    title={title}
+                >
+                    <Link href={`/questions/${slug}`}>{title}</Link>
+                </span>
+
+                <div className="flex items-center">{isPublic ? <UnlockIcon /> : <LockIcon />}</div>
             </div>
-            <div className="flex gap-3">
-                <div className="flex flex-col gap-2">
-                    <p className="text-[12px] leading-4 line-clamp-3">
-                        Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in. Lorem
-                        ipsum dolor sit amet consectetur. Sed amet at id sit proin in. Lorem ipsum
-                        dolor sit amet consectetur. Sed amet at id sit proin in. Lorem ipsum dolor
-                        sit amet consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit
-                        amet consectetur. Sed amet at id sit proin in.
+            <div className="flex flex-1 gap-3">
+                <div className="flex flex-1 flex-col gap-2">
+                    <p className="break-all text-[12px] leading-4 line-clamp-3">
+                        {parseHTML(content)}
                     </p>
-                    <div className="flex w-fit gap-1 rounded-[4px] border border-primary-base px-1 py-[2px] text-primary-base">
+                    <div className="mt-auto flex w-fit gap-1 rounded-[4px] border border-primary-base px-1 py-[2px] text-primary-base">
                         <div>
                             <ThumbUpIcon />
                         </div>
-                        <span className="text-xs font-bold">87%</span>
+                        <span className="text-xs font-bold">{upvotePercentage.toFixed()}%</span>
                     </div>
                 </div>
                 <div className="flex min-w-fit flex-col items-end text-xs font-light">
-                    <span>10 Votes</span>
-                    <span>5 Answers</span>
-                    <span>29 Views</span>
+                    <span>{voteCount} Votes</span>
+                    <span>{answerCount} Answers</span>
+                    <span>{viewCount} Views</span>
                 </div>
             </div>
-            <div className="flex flex-col gap-1">
-                <Tags
-                    values={[
-                        {
-                            id: 1,
-                            slug: 'javascript',
-                            name: 'JavaScript',
-                            description: 'JavaScript questions',
-                            is_watched_by_user: true,
-                        },
-                        {
-                            id: 2,
-                            slug: 'typeScript',
-                            name: 'TypeScript',
-                            description: 'TypeScript questions',
-                            is_watched_by_user: false,
-                        },
-                        {
-                            id: 3,
-                            slug: 'javascript',
-                            name: 'JavaScript',
-                            description: 'JavaScript questions',
-                            is_watched_by_user: true,
-                        },
-                        {
-                            id: 4,
-                            slug: 'typeScript',
-                            name: 'TypeScript',
-                            description: 'TypeScript questions',
-                            is_watched_by_user: false,
-                        },
-                        {
-                            id: 5,
-                            slug: 'javascript',
-                            name: 'JavaScript',
-                            description: 'JavaScript questions',
-                            is_watched_by_user: true,
-                        },
-                        {
-                            id: 6,
-                            slug: 'typeScript',
-                            name: 'TypeScript',
-                            description: 'TypeScript questions',
-                            is_watched_by_user: false,
-                        },
-                    ]}
-                />
+            <div className="mt-auto flex flex-col gap-1">
+                <Tags values={tags} />
                 <div className="flex justify-between text-xs">
                     <span>
-                        Author:{' '}
-                        <Link href="#" className="text-primary-blue">
-                            John Doe
+                        {`Author: `}
+                        <Link href={`/users/${String(author.slug)}`} className="text-primary-blue">
+                            {author.first_name} {author.last_name}
                         </Link>
                     </span>
-                    <time>2022-12-02</time>
+                    <time>{new Date(createdAt).toISOString().substring(0, 10)}</time>
                 </div>
             </div>
         </div>

--- a/frontend/components/organisms/QuestionListItem/index.tsx
+++ b/frontend/components/organisms/QuestionListItem/index.tsx
@@ -9,8 +9,8 @@ type QuestionListItemProps = {
     title: string
     content: string
     voteCount: number
-    answerCount: number
-    viewCount: number
+    answerCount?: number
+    viewCount?: number
     isPublic: boolean
     tags: TagType[]
     author: UserType
@@ -32,10 +32,20 @@ const QuestionListItem = ({
     return (
         <div className="border-b-2 border-y-neutral-200 p-2 text-neutral-900">
             <div className="flex w-full items-start gap-4 ">
-                <div className="flex min-w-fit flex-col items-end pt-1 text-xs font-light">
-                    <span>{voteCount} Votes</span>
-                    <span>{answerCount} Answers</span>
-                    <span>{viewCount} Views</span>
+                <div className="flex min-w-fit flex-col items-end gap-1 pt-1 text-xs font-light">
+                    <span>
+                        {voteCount} {voteCount === 1 ? 'Vote' : 'Votes'}
+                    </span>
+                    {answerCount !== undefined && (
+                        <span>
+                            {answerCount} {answerCount === 1 ? 'Answer' : 'Answers'}
+                        </span>
+                    )}
+                    {viewCount !== undefined && (
+                        <span>
+                            {viewCount} {viewCount === 1 ? 'View' : 'Views'}
+                        </span>
+                    )}
                 </div>
                 <div className="flex h-32 w-9/12 flex-col gap-2 xl:w-full">
                     <span className="truncate text-sm font-semibold hover:text-primary-base">
@@ -51,7 +61,7 @@ const QuestionListItem = ({
                     />
                 </div>
             </div>
-            <div className="flex justify-end text-xs">
+            <div className="flex justify-end text-[10px]">
                 <span>
                     <Link href={`/users/${String(author.slug)}`} className="text-primary-blue">
                         {author.first_name} {author.last_name}

--- a/frontend/components/organisms/QuestionListItem/index.tsx
+++ b/frontend/components/organisms/QuestionListItem/index.tsx
@@ -1,60 +1,62 @@
 import Privacy from '@/components/molecules/Privacy'
 import Tags from '@/components/molecules/Tags'
+import { parseHTML } from '@/helpers/htmlParsing'
+import type { TagType, UserType } from '@/pages/questions/[slug]'
 import Link from 'next/link'
 
 type QuestionListItemProps = {
-    id: number
-    privacy: 'Public' | 'Private'
+    slug: string
+    title: string
+    content: string
+    voteCount: number
+    answerCount: number
+    viewCount: number
+    isPublic: boolean
+    tags: TagType[]
+    author: UserType
+    createdAt: string
 }
 
-const QuestionListItem = ({ id, privacy }: QuestionListItemProps): JSX.Element => {
+const QuestionListItem = ({
+    slug,
+    title,
+    content,
+    voteCount,
+    answerCount,
+    viewCount,
+    isPublic,
+    tags,
+    author,
+    createdAt,
+}: QuestionListItemProps): JSX.Element => {
     return (
         <div className="border-b-2 border-y-neutral-200 p-2 text-neutral-900">
-            <div className="flex  w-full items-start gap-4 ">
+            <div className="flex w-full items-start gap-4 ">
                 <div className="flex min-w-fit flex-col items-end pt-1 text-xs font-light">
-                    <span>10 Votes</span>
-                    <span>5 Answers</span>
-                    <span>29 Views</span>
+                    <span>{voteCount} Votes</span>
+                    <span>{answerCount} Answers</span>
+                    <span>{viewCount} Views</span>
                 </div>
-                <div className="flex h-32 w-full flex-col gap-2">
-                    <span className="text-base font-semibold">Question Title</span>
-                    <p className="text-[12px]">
-                        Lorem ipsum dolor sit amet consectetur. Viverra mauris at dui platea ut
-                        velit at in. Volutpat tristique varius aliquet faucibus mauris pellentesque
-                        cursus.
-                    </p>
-                    <Tags
-                        values={[
-                            {
-                                id: 1,
-                                slug: 'javascript',
-                                name: 'JavaScript',
-                                description: 'JavaScript questions',
-                                is_watched_by_user: true,
-                            },
-                            {
-                                id: 2,
-                                slug: 'typeScript',
-                                name: 'TypeScript',
-                                description: 'TypeScript questions',
-                                is_watched_by_user: false,
-                            },
-                        ]}
-                    />
+                <div className="flex h-32 w-9/12 flex-col gap-2 xl:w-full">
+                    <span className="truncate text-sm font-semibold hover:text-primary-base">
+                        <Link href={`/questions/${slug}`}>{title}</Link>
+                    </span>
+                    <p className="break-all text-[12px] line-clamp-2">{parseHTML(content)}</p>
+                    <Tags values={tags} />
                 </div>
                 <div className="flex w-[5.5rem] justify-end">
                     <Privacy
-                        name={privacy}
-                        additionalClass={`${privacy === 'Public' ? 'text-neutral-disabled' : ''}`}
+                        name={isPublic ? 'Public' : 'Private'}
+                        additionalClass={`${isPublic ? 'text-neutral-disabled' : ''}`}
                     />
                 </div>
             </div>
             <div className="flex justify-end text-xs">
                 <span>
-                    <Link href="#" className="text-primary-blue">
-                        John Doe
-                    </Link>{' '}
-                    asked 2hrs ago
+                    <Link href={`/users/${String(author.slug)}`} className="text-primary-blue">
+                        {author.first_name} {author.last_name}
+                    </Link>
+                    {` asked ${createdAt}`}
                 </span>
             </div>
         </div>

--- a/frontend/helpers/graphql/queries/get_answers.ts
+++ b/frontend/helpers/graphql/queries/get_answers.ts
@@ -18,6 +18,7 @@ const GET_ANSWERS = gql`
             data {
                 id
                 content
+                upvote_percentage
                 created_at
                 updated_at
                 user {

--- a/frontend/helpers/graphql/queries/get_answers.ts
+++ b/frontend/helpers/graphql/queries/get_answers.ts
@@ -1,0 +1,62 @@
+import { gql } from '@apollo/client'
+
+const GET_ANSWERS = gql`
+    query Answers(
+        $first: Int!
+        $page: Int!
+        $filter: answerFilter
+        $orderBy: [QueryAnswersOrderByOrderByClause!]
+    ) {
+        answers(first: $first, page: $page, filter: $filter, orderBy: $orderBy) {
+            paginatorInfo {
+                perPage
+                currentPage
+                lastPage
+                hasMorePages
+                total
+            }
+            data {
+                id
+                content
+                created_at
+                updated_at
+                user {
+                    id
+                    slug
+                }
+                question {
+                    id
+                    slug
+                    title
+                    content
+                    vote_count
+                    upvote_percentage
+                    views_count
+                    humanized_created_at
+                    created_at
+                    is_public
+                    user {
+                        id
+                        slug
+                        first_name
+                        last_name
+                    }
+                    tags {
+                        id
+                        name
+                        is_watched_by_user
+                        slug
+                        description
+                        count_tagged_questions
+                        count_watching_users
+                    }
+                    answers {
+                        id
+                    }
+                }
+            }
+        }
+    }
+`
+
+export default GET_ANSWERS

--- a/frontend/helpers/graphql/queries/get_questions.ts
+++ b/frontend/helpers/graphql/queries/get_questions.ts
@@ -22,6 +22,7 @@ const GET_QUESTIONS = gql`
                 created_at
                 slug
                 vote_count
+                upvote_percentage
                 views_count
                 humanized_created_at
                 is_from_user

--- a/frontend/helpers/graphql/queries/get_questions.ts
+++ b/frontend/helpers/graphql/queries/get_questions.ts
@@ -4,10 +4,17 @@ const GET_QUESTIONS = gql`
     query Questions(
         $first: Int!
         $page: Int!
+        $isAdmin: Boolean
         $filter: filter
         $orderBy: [QueryQuestionsOrderByOrderByClause!]
     ) {
-        questions(first: $first, page: $page, filter: $filter, orderBy: $orderBy) {
+        questions(
+            first: $first
+            page: $page
+            isAdmin: $isAdmin
+            filter: $filter
+            orderBy: $orderBy
+        ) {
             paginatorInfo {
                 perPage
                 currentPage

--- a/frontend/helpers/graphql/queries/get_teams.ts
+++ b/frontend/helpers/graphql/queries/get_teams.ts
@@ -1,8 +1,14 @@
 import { gql } from '@apollo/client'
 
 const GET_TEAMS = gql`
-    query Teams($first: Int!, $page: Int!, $name: String, $isAdmin: Boolean) {
-        getUserTeams(first: $first, page: $page, name: $name, isAdmin: $isAdmin) {
+    query Teams($first: Int!, $page: Int!, $name: String, $isAdmin: Boolean, $user_slug: String) {
+        getUserTeams(
+            first: $first
+            page: $page
+            name: $name
+            isAdmin: $isAdmin
+            user_slug: $user_slug
+        ) {
             paginatorInfo {
                 perPage
                 currentPage

--- a/frontend/pages/manage/users/[slug]/hooks/useTabData.ts
+++ b/frontend/pages/manage/users/[slug]/hooks/useTabData.ts
@@ -1,0 +1,124 @@
+import { type PaginatorInfo } from '@/components/templates/QuestionsPageLayout'
+import GET_ANSWERS from '@/helpers/graphql/queries/get_answers'
+import GET_QUESTIONS from '@/helpers/graphql/queries/get_questions'
+import GET_TEAMS from '@/helpers/graphql/queries/get_teams'
+import GET_USER from '@/helpers/graphql/queries/get_user'
+import { answerFilterOption, orderByOptions, type RefetchType } from '@/pages/questions'
+import { type AnswerType, type QuestionType, type TeamType } from '@/pages/questions/[slug]'
+import { useLazyQuery, useQuery } from '@apollo/client'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { type Tab, type View } from '..'
+
+type QuestionQueryType = {
+    questions: { data: QuestionType[]; paginatorInfo: PaginatorInfo }
+}
+
+type AnswerQueryType = {
+    answers: { data: AnswerType[]; paginatorInfo: PaginatorInfo }
+}
+
+type TeamQueryType = {
+    getUserTeams: { data: TeamType[]; paginatorInfo: PaginatorInfo }
+}
+
+type TeamRefetchType = {
+    first: number
+    page: number
+    user_slug: string
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const useTabData = (activeTab: Tab, view: View) => {
+    const router = useRouter()
+
+    const order = orderByOptions[String(router.query.order ?? 'Newest first')]
+    const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
+
+    // User
+    const {
+        data: userData,
+        loading: userLoading,
+        error: userError,
+    } = useQuery(GET_USER, {
+        variables: {
+            slug: router.query.slug,
+        },
+    })
+
+    // Questions
+    const [
+        getUserQuestions,
+        {
+            data: userQuestions,
+            loading: questionsLoading,
+            error: questionsError,
+            refetch: questionsRefetch,
+        },
+    ] = useLazyQuery<QuestionQueryType, RefetchType>(GET_QUESTIONS, { fetchPolicy: 'network-only' })
+
+    // Answers
+    const [
+        getUserAnswers,
+        {
+            data: userAnswers,
+            loading: answersLoading,
+            error: answersError,
+            refetch: answersRefetch,
+        },
+    ] = useLazyQuery<AnswerQueryType, RefetchType>(GET_ANSWERS, {
+        fetchPolicy: 'network-only',
+    })
+
+    // Teams
+    const [
+        getUserTeams,
+        { data: userTeams, loading: teamsLoading, error: teamsError, refetch: teamsRefetch },
+    ] = useLazyQuery<TeamQueryType, TeamRefetchType>(GET_TEAMS, { fetchPolicy: 'network-only' })
+    useEffect(() => {
+        if (activeTab === 'Questions') {
+            void getUserQuestions({
+                variables: {
+                    first: view === 'List' ? 5 : 12,
+                    page: 1,
+                    filter: { user_slug: router.query.slug as string, ...answerFilter },
+                    orderBy: [order],
+                },
+            })
+        } else if (activeTab === 'Answers') {
+            void getUserAnswers({
+                variables: {
+                    first: view === 'List' ? 5 : 12,
+                    page: 1,
+                    filter: { user_slug: router.query.slug as string, ...answerFilter },
+                    orderBy: [order],
+                },
+            })
+        } else if (activeTab === 'Teams') {
+            void getUserTeams({
+                variables: {
+                    first: 12,
+                    page: 1,
+                    user_slug: router.query.slug as string,
+                },
+            })
+        }
+    }, [activeTab, view, router])
+
+    const loading = questionsLoading || answersLoading || teamsLoading || userLoading
+    const error = questionsError ?? answersError ?? teamsError ?? userError
+
+    return {
+        userData,
+        userQuestions: userQuestions?.questions,
+        userAnswers: userAnswers?.answers,
+        userTeams: userTeams?.getUserTeams,
+        loading,
+        error,
+        questionsRefetch,
+        answersRefetch,
+        teamsRefetch,
+    }
+}
+
+export default useTabData

--- a/frontend/pages/manage/users/[slug]/hooks/useTabData.ts
+++ b/frontend/pages/manage/users/[slug]/hooks/useTabData.ts
@@ -81,6 +81,7 @@ const useTabData = (activeTab: Tab, view: View) => {
                 variables: {
                     first: view === 'List' ? 5 : 12,
                     page: 1,
+                    isAdmin: true,
                     filter: { user_slug: router.query.slug as string, ...answerFilter },
                     orderBy: [order],
                 },

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -1,159 +1,266 @@
-import { CustomIcons } from '@/components/atoms/Icons'
+import DropdownFilters from '@/components/molecules/DropdownFilters'
+import ProfileCard from '@/components/molecules/ProfileCard'
 import TeamCard from '@/components/molecules/TeamCard'
 import ViewToggle from '@/components/molecules/ViewToggle'
+import Paginate from '@/components/organisms/Paginate'
 import QuestionGridItem from '@/components/organisms/QuestionGridItem'
 import QuestionListItem from '@/components/organisms/QuestionListItem'
-import GET_USER from '@/helpers/graphql/queries/get_user'
+import { type PaginatorInfo } from '@/components/templates/QuestionsPageLayout'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
-import { useQuery } from '@apollo/client'
+import { answerFilterOption, orderByOptions } from '@/pages/questions'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import useTabData from './hooks/useTabData'
 
-const { ChevronIcon, DotsIcon } = CustomIcons
-
-interface UserType {
-    id: number
-    first_name: string
-    last_name: string
-    avatar: string
-    question_count: number
-    answer_count: number
-    reputation: number
-}
+export type View = 'Grid' | 'List'
+export type Tab = 'Questions' | 'Answers' | 'Teams'
 
 const getActiveTabClass = (status: boolean): string => {
     return `-mb-[0.5px] p-[0.625rem] font-bold cursor-pointer hover:text-primary-base
     ${status ? 'border-b-2 border-primary-base bg-primary-200' : ''}`
 }
 
-export type View = 'Grid' | 'List'
-type Tab = 'Questions' | 'Answers' | 'Teams'
-
 const UserDetail = (): JSX.Element => {
     const router = useRouter()
+    const view = String(router.query.view ?? 'List') as View
+    const activeTab = (router.query.tab ?? 'Questions') as Tab
+    const order = orderByOptions[String(router.query.order ?? 'Newest first')]
+    const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
 
-    const [view, setView] = useState<View>('List')
+    const {
+        userData,
+        userQuestions,
+        userAnswers,
+        userTeams,
+        loading,
+        error,
+        questionsRefetch,
+        answersRefetch,
+        teamsRefetch,
+    } = useTabData(activeTab, view)
 
-    const [activeTab, setActiveTab] = useState<Tab>('Questions')
-    const userQuery = useQuery<{ user: UserType }>(GET_USER, {
-        variables: { slug: router.query.slug },
-    })
+    if (loading) return loadingScreenShow()
+    if (error) {
+        return <>{errorNotify(`Error! ${error?.message ?? ''}`)}</>
+    }
 
-    if (userQuery.loading) return loadingScreenShow()
-    if (userQuery.error) {
-        errorNotify(`Error! ${userQuery.error?.message ?? ''}`)
-        return <></>
+    const onPageChange = async (first: number, page: number): Promise<void> => {
+        switch (activeTab) {
+            case 'Questions':
+                void questionsRefetch({
+                    first,
+                    page,
+                    filter: { user_slug: router.query.slug as string, ...answerFilter },
+                    orderBy: [order],
+                })
+                break
+            case 'Answers':
+                void answersRefetch({
+                    first,
+                    page,
+                    filter: { user_slug: router.query.slug as string, ...answerFilter },
+                    orderBy: [order],
+                })
+                break
+            case 'Teams':
+                void teamsRefetch({
+                    first,
+                    page,
+                    user_slug: router.query.slug as string,
+                })
+        }
+    }
+
+    const getPageInfo = (): PaginatorInfo | undefined => {
+        switch (activeTab) {
+            case 'Questions':
+                return userQuestions?.paginatorInfo
+            case 'Answers':
+                return userAnswers?.paginatorInfo
+            case 'Teams':
+                return userTeams?.paginatorInfo
+        }
     }
 
     const toggleView = (): void => {
-        setView((prevView) => (prevView === 'List' ? 'Grid' : 'List'))
+        void router.push({
+            pathname: router.pathname,
+            query: { ...router.query, view: view === 'List' ? 'Grid' : 'List' },
+        })
     }
 
-    return (
-        <div className="h-full rounded-[5px] border border-neutral-200 bg-white p-4 text-sm text-neutral-900">
-            <div className="flex h-full flex-col gap-4">
-                <div className="flex h-[37px] border-b-[0.5px] border-neutral-disabled">
-                    <div
-                        className={getActiveTabClass(activeTab === 'Questions')}
-                        onClick={() => {
-                            setActiveTab('Questions')
-                        }}
-                    >
-                        Questions
-                    </div>
-                    <div
-                        className={getActiveTabClass(activeTab === 'Answers')}
-                        onClick={() => {
-                            setActiveTab('Answers')
-                        }}
-                    >
-                        Answers
-                    </div>
-                    <div
-                        className={getActiveTabClass(activeTab === 'Teams')}
-                        onClick={() => {
-                            setActiveTab('Teams')
-                        }}
-                    >
-                        Teams
-                    </div>
-                </div>
-                {activeTab !== 'Teams' && (
-                    <div className="flex justify-end gap-1">
-                        <div onClick={toggleView}>
-                            <ViewToggle view={view} />
-                        </div>
-                        <div className="flex gap-[2px] rounded-[5px] border border-neutral-900 p-2">
-                            <span>Newest First</span>
-                            <div className="m-auto">
-                                <ChevronIcon />
-                            </div>
-                        </div>
-                        <div className="flex rounded-[5px] border border-neutral-900 p-2">
-                            <span>All Questions</span>
-                            <div className="m-auto">
-                                <DotsIcon />
-                            </div>
-                        </div>
-                    </div>
-                )}
-                {activeTab === 'Teams' ? (
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-                        <TeamCard
-                            name="Sun Overflow"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in. Lorem ipsum
-                    dolor sit amet consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit
-                    amet consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in. Lorem ipsum dolor sit amet
-                    consectetur. Sed amet at id sit proin in."
-                            usersCount={123}
-                        />
-                        <TeamCard
-                            name="MetaJobs"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in."
-                            usersCount={444}
-                        />
-                        <TeamCard
-                            name="Meetsone"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in."
-                            usersCount={55}
-                        />
-                        <TeamCard
-                            name="Zeon"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in."
-                            usersCount={24}
-                        />
-                        <TeamCard
-                            name="OsakaMetro"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in."
-                            usersCount={12}
-                        />
-                        <TeamCard
-                            name="Prrr"
-                            description="Lorem ipsum dolor sit amet consectetur. Sed amet at id sit proin in."
-                            usersCount={100}
-                        />
-                    </div>
-                ) : view === 'List' ? (
-                    <div className="flex w-full flex-col justify-center gap-4">
-                        <QuestionListItem id={1} privacy="Public" />
-                        <QuestionListItem id={2} privacy="Private" />
-                        <QuestionListItem id={3} privacy="Private" />
-                    </div>
+    const renderEmptyList = (): JSX.Element => {
+        return (
+            <div className="flex justify-center">
+                <span>No {activeTab} to Show</span>
+            </div>
+        )
+    }
+
+    const renderUserQuestions = (): JSX.Element[] | null => {
+        return (
+            userQuestions?.data.map((question) => {
+                const questionProps = {
+                    key: question.id,
+                    slug: question.slug,
+                    title: question.title,
+                    content: question.content,
+                    voteCount: question.vote_count,
+                    answerCount: question.answers?.length,
+                    viewCount: question.views_count,
+                    isPublic: question.is_public,
+                    tags: question.tags,
+                    author: question.user,
+                }
+                return view === 'List' ? (
+                    <QuestionListItem
+                        {...questionProps}
+                        createdAt={question.humanized_created_at}
+                    />
                 ) : (
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                        <QuestionGridItem />
-                        <QuestionGridItem />
-                        <QuestionGridItem />
-                        <QuestionGridItem />
-                        <QuestionGridItem />
+                    <QuestionGridItem
+                        {...questionProps}
+                        upvotePercentage={question.upvote_percentage}
+                        createdAt={question.created_at}
+                    />
+                )
+            }) ?? null
+        )
+    }
+
+    const renderUserAnswers = (): JSX.Element[] | null => {
+        return (
+            userAnswers?.data.map((answer) => {
+                const { question } = answer
+
+                const questionProps = {
+                    key: question.id,
+                    slug: question.slug,
+                    title: question.title,
+                    content: question.content,
+                    voteCount: question.vote_count,
+                    answerCount: question.answers?.length,
+                    viewCount: question.views_count,
+                    isPublic: question.is_public,
+                    tags: question.tags,
+                    author: question.user,
+                }
+                return view === 'List' ? (
+                    <QuestionListItem
+                        {...questionProps}
+                        createdAt={question.humanized_created_at}
+                    />
+                ) : (
+                    <QuestionGridItem
+                        {...questionProps}
+                        upvotePercentage={question.upvote_percentage}
+                        createdAt={question.created_at}
+                    />
+                )
+            }) ?? null
+        )
+    }
+
+    const tabHandler = (tab: Tab): void => {
+        void router.push({
+            pathname: router.pathname,
+            query: { ...router.query, tab },
+        })
+    }
+
+    const pageInfo = getPageInfo()
+    const user = userData.user
+    return (
+        <div className="flex flex-col gap-4 p-4 xl:flex-row">
+            <ProfileCard isAdmin {...user} isPublic={true} toggleFollow={() => {}} />
+            <div className="h-full w-full rounded-[5px] border border-neutral-200 bg-white p-4 text-sm text-neutral-900">
+                <div className="flex h-full flex-col gap-4">
+                    <div className="flex h-[37px] border-b-[0.5px] border-neutral-disabled">
+                        <div
+                            className={getActiveTabClass(activeTab === 'Questions')}
+                            onClick={() => {
+                                tabHandler('Questions')
+                            }}
+                        >
+                            Questions
+                        </div>
+                        <div
+                            className={getActiveTabClass(activeTab === 'Answers')}
+                            onClick={() => {
+                                const { query } = router
+                                delete query.filter
+                                tabHandler('Answers')
+                            }}
+                        >
+                            Answers
+                        </div>
+                        <div
+                            className={getActiveTabClass(activeTab === 'Teams')}
+                            onClick={() => {
+                                const { query } = router
+                                delete query.view
+                                delete query.order
+                                delete query.filter
+                                tabHandler('Teams')
+                            }}
+                        >
+                            Teams
+                        </div>
                     </div>
-                )}
+                    {activeTab !== 'Teams' && (
+                        <div className="flex justify-end gap-1">
+                            <div onClick={toggleView}>
+                                <ViewToggle view={view} />
+                            </div>
+                            <div className="">
+                                <DropdownFilters
+                                    triggers={
+                                        activeTab === 'Questions' ? ['DATE', 'ANSWER'] : ['DATE']
+                                    }
+                                />
+                            </div>
+                        </div>
+                    )}
+                    {activeTab === 'Teams' ? (
+                        <div>
+                            {!userTeams && renderEmptyList()}
+                            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                                {userTeams?.data.map((team) => {
+                                    return (
+                                        <TeamCard
+                                            key={team.id}
+                                            slug={team.slug ?? ''}
+                                            name={team.name}
+                                            description={team.description}
+                                            usersCount={team.members_count}
+                                        />
+                                    )
+                                })}
+                            </div>
+                        </div>
+                    ) : view === 'List' ? (
+                        <div>
+                            {!userQuestions && !userAnswers && renderEmptyList()}
+                            <div className="flex w-full flex-col justify-center gap-4">
+                                {activeTab === 'Questions'
+                                    ? renderUserQuestions()
+                                    : renderUserAnswers()}
+                            </div>
+                        </div>
+                    ) : (
+                        <div>
+                            {!userQuestions && !userAnswers && renderEmptyList()}
+                            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                                {activeTab === 'Questions'
+                                    ? renderUserQuestions()
+                                    : renderUserAnswers()}
+                            </div>
+                        </div>
+                    )}
+                    {pageInfo && pageInfo.lastPage > 1 && (
+                        <Paginate {...pageInfo} onPageChange={onPageChange} />
+                    )}
+                </div>
             </div>
         </div>
     )

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -89,9 +89,20 @@ const UserDetail = (): JSX.Element => {
         })
     }
 
-    const renderEmptyList = (): JSX.Element => {
+    const renderEmptyList = (): JSX.Element | null => {
+        switch (activeTab) {
+            case 'Questions':
+                if (userQuestions?.data.length) return null
+                break
+            case 'Answers':
+                if (userAnswers?.data.length) return null
+                break
+            case 'Teams':
+                if (userTeams?.data.length) return null
+        }
+
         return (
-            <div className="flex justify-center">
+            <div className="flex justify-center py-2 text-neutral-500">
                 <span>No {activeTab} to Show</span>
             </div>
         )
@@ -137,10 +148,8 @@ const UserDetail = (): JSX.Element => {
                     key: question.id,
                     slug: question.slug,
                     title: question.title,
-                    content: question.content,
+                    content: answer.content,
                     voteCount: question.vote_count,
-                    answerCount: question.answers?.length,
-                    viewCount: question.views_count,
                     isPublic: question.is_public,
                     tags: question.tags,
                     author: question.user,
@@ -153,7 +162,7 @@ const UserDetail = (): JSX.Element => {
                 ) : (
                     <QuestionGridItem
                         {...questionProps}
-                        upvotePercentage={question.upvote_percentage}
+                        upvotePercentage={answer.upvote_percentage}
                         createdAt={question.created_at}
                     />
                 )
@@ -221,9 +230,9 @@ const UserDetail = (): JSX.Element => {
                             </div>
                         </div>
                     )}
+                    {renderEmptyList()}
                     {activeTab === 'Teams' ? (
                         <div>
-                            {!userTeams && renderEmptyList()}
                             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                                 {userTeams?.data.map((team) => {
                                     return (
@@ -240,7 +249,6 @@ const UserDetail = (): JSX.Element => {
                         </div>
                     ) : view === 'List' ? (
                         <div>
-                            {!userQuestions && !userAnswers && renderEmptyList()}
                             <div className="flex w-full flex-col justify-center gap-4">
                                 {activeTab === 'Questions'
                                     ? renderUserQuestions()
@@ -249,7 +257,6 @@ const UserDetail = (): JSX.Element => {
                         </div>
                     ) : (
                         <div>
-                            {!userQuestions && !userAnswers && renderEmptyList()}
                             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                                 {activeTab === 'Questions'
                                     ? renderUserQuestions()

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -52,13 +52,15 @@ export type AnswerType = {
     user: UserType
     is_from_user: boolean
     comments: CommentType[]
-    question: { slug: string }
+    question: QuestionType
 }
 
 export type TeamType = {
     id: number
     name: string
     slug?: string
+    description: string
+    members_count: number
 }
 
 export type QuestionType = {
@@ -68,6 +70,7 @@ export type QuestionType = {
     content: string
     created_at: string
     vote_count: number
+    upvote_percentage: number
     views_count: number
     humanized_created_at: string
     is_public: boolean

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -44,6 +44,7 @@ export type AnswerType = {
     content: string
     created_at: string
     vote_count: number
+    upvote_percentage: number
     humanized_created_at: string
     is_bookmarked: boolean
     is_correct: boolean

--- a/frontend/pages/questions/index.tsx
+++ b/frontend/pages/questions/index.tsx
@@ -17,6 +17,7 @@ export type RefetchType = {
         team?: string
         user_slug?: string
     }
+    isAdmin?: boolean
     orderBy?: Array<{ column: string; order: string }>
     sort?: Array<{ column: string; order: string }>
 }

--- a/frontend/pages/questions/index.tsx
+++ b/frontend/pages/questions/index.tsx
@@ -10,7 +10,13 @@ export type RefetchType = {
     first: number
     page: number
     name?: string
-    filter?: { keyword?: string; answered?: boolean; tag?: string; team?: string }
+    filter?: {
+        keyword?: string
+        answered?: boolean
+        tag?: string
+        team?: string
+        user_slug?: string
+    }
     orderBy?: Array<{ column: string; order: string }>
     sort?: Array<{ column: string; order: string }>
 }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-361

## Commands
Go to Admin User Detail Page or `http://localhost:3000/manage/users/<user-slug>`

## Pre-conditions
- You must have access to the page (You can comment `AdminWrapper` temporarily)

## Expected Output
- [x] You should be able to see the questions posted by a user
- [x] You should be able to see the answers posted by a user
- [x] You should be able to see the teams of a user
- [x] You should be able to switch from `List View` to `Grid View`
- [x] You should be able to filter the questions

## Notes
- Dependent on branch `feature/refactor-profile-page`

## Screenshots
Questions Tab (List View)
![image](https://user-images.githubusercontent.com/111732984/234481346-0923da5d-f406-4d1d-bbad-c73ac0e7172b.png)
Questions Tab (Grid View)
![image](https://user-images.githubusercontent.com/111732984/234481386-7a57010e-0923-4600-9983-8308558ef059.png)
Answers Tab (List View)
![image](https://user-images.githubusercontent.com/111732984/234481480-83f02122-9e1e-4768-8e7c-5b1dd60741e7.png)
Answers Tab (Grid View)
![image](https://user-images.githubusercontent.com/111732984/234481423-564b008f-b053-4b5d-8771-42c9501d678e.png)
Teams Tab
![image](https://user-images.githubusercontent.com/111732984/234481523-87de2c72-8885-4ad1-85c2-bb91fe8248e7.png)
