### PR TITLE
[Overflow-465] [BUGFIX] Retain Data Fetched from Filters After Refresh/Redirect

### DIFF
--- a/backend/graphql/question/query.graphql
+++ b/backend/graphql/question/query.graphql
@@ -14,7 +14,7 @@ enum ORDERBY {
 }
 
 enum COLUMNS {
-    CREATED_AT @enum(value: "created_at")
+    UPDATED_AT @enum(value: "updated_at")
     VOTES @enum(value: "votes_sum_value")
 }
 

--- a/frontend/components/molecules/Dropdown/index.tsx
+++ b/frontend/components/molecules/Dropdown/index.tsx
@@ -48,7 +48,6 @@ const selectStyles: StylesConfig<any, false, any> = {
 }
 
 const Dropdown = ({ name, label, options, onChange, value, isError }: FormProps): JSX.Element => {
-    console.log(value)
     return (
         <div className="w-full">
             <div className="mb-2 text-sm font-medium capitalize text-neutral-900">{label}</div>

--- a/frontend/components/molecules/DropdownFilters/index.tsx
+++ b/frontend/components/molecules/DropdownFilters/index.tsx
@@ -1,10 +1,7 @@
-import type { ApolloQueryResult } from '@apollo/client'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import type { RefetchType } from '../../../pages/questions/index'
 import SortDropdown from '../SortDropdown'
 
-type TriggerType = 'DATE' | 'ANSWER' | 'WATCHED' | 'POPULAR'
+type TriggerType = 'DATE' | 'ANSWER'
 
 type FilterType = {
     state: string
@@ -18,181 +15,90 @@ type FilterType = {
 type FilterTextsType = {
     DATE: { 1: string; 2: string; 3: string; 4: string }
     ANSWER: { 1: string; 2: string; 3: string }
-    WATCHED: { 1: string; 2: string }
-    POPULAR: { 1: string; 2: string }
 }
 
 type FilterListsType = {
     DATE: FilterType
     ANSWER: FilterType
-    WATCHED: FilterType
-    POPULAR: FilterType
 }
 
 type Props = {
     triggers: TriggerType[]
-    searchKey?: string
-    tag?: string
-    team?: string
-    refetch: ({ first, page, orderBy, filter }: RefetchType) => Promise<ApolloQueryResult<any>>
 }
 
-const FilterTexts: FilterTextsType = {
+const filterTexts: FilterTextsType = {
     DATE: { 1: 'Newest first', 2: 'Oldest first', 3: 'Most recent', 4: 'Least recent' },
-    ANSWER: { 1: 'Answered', 2: 'Unanswered', 3: 'All Questions' },
-    WATCHED: { 1: 'Most Watched', 2: 'Least Watched' },
-    POPULAR: { 1: 'Most Popular', 2: 'Least Popular' },
+    ANSWER: { 1: 'All Questions', 2: 'Answered', 3: 'Unanswered' },
 }
 
-const DropdownFilters = ({
-    triggers,
-    searchKey = '',
-    tag = '',
-    team = '',
-    refetch,
-}: Props): JSX.Element => {
+const DropdownFilters = ({ triggers }: Props): JSX.Element => {
     const router = useRouter()
-    const [selectedDateFilter, setSelectedDateFilter] = useState(FilterTexts.DATE[1])
-    const [selectedAnswerFilter, setSelectedAnswerFilter] = useState(FilterTexts.ANSWER[1])
-    const [selectedWatchedFilter, setSelectedWatchedFilter] = useState(FilterTexts.WATCHED[1])
-    const [selectedPopularFilter, setSelectedPopularFilter] = useState(FilterTexts.POPULAR[1])
 
-    useEffect(() => {
-        setSelectedDateFilter(FilterTexts.DATE[1])
-        setSelectedAnswerFilter(FilterTexts.ANSWER[3])
-        setSelectedWatchedFilter(FilterTexts.WATCHED[1])
-        setSelectedPopularFilter(FilterTexts.POPULAR[1])
-    }, [router])
+    const routerHandler = (order: string, filter: string): void => {
+        void router.push({
+            pathname: router.pathname,
+            query: { ...router.query, order, filter },
+        })
+    }
 
-    const FilterLists: FilterListsType = {
+    const order = String(router.query.order ?? filterTexts.DATE[1])
+    const filter = String(router.query.filter ?? filterTexts.ANSWER[1])
+    const filterLists: FilterListsType = {
         DATE: {
-            state: selectedDateFilter,
+            state: order,
             filters: [
                 {
                     id: 1,
-                    name: FilterTexts.DATE[1],
+                    name: filterTexts.DATE[1],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-                        })
-                        setSelectedDateFilter(FilterTexts.DATE[1])
+                        routerHandler(filterTexts.DATE[1], filter)
                     },
                 },
                 {
                     id: 2,
-                    name: FilterTexts.DATE[2],
+                    name: filterTexts.DATE[2],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            orderBy: [{ column: 'CREATED_AT', order: 'ASC' }],
-                        })
-                        setSelectedDateFilter(FilterTexts.DATE[2])
+                        routerHandler(filterTexts.DATE[2], filter)
                     },
                 },
                 {
                     id: 3,
-                    name: FilterTexts.DATE[3],
+                    name: filterTexts.DATE[3],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            orderBy: [{ column: 'UPDATED_AT', order: 'DESC' }],
-                        })
-                        setSelectedDateFilter(FilterTexts.DATE[3])
+                        routerHandler(filterTexts.DATE[3], filter)
                     },
                 },
                 {
                     id: 4,
-                    name: FilterTexts.DATE[4],
+                    name: filterTexts.DATE[4],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            orderBy: [{ column: 'UPDATED_AT', order: 'ASC' }],
-                        })
-                        setSelectedDateFilter(FilterTexts.DATE[4])
+                        routerHandler(filterTexts.DATE[4], filter)
                     },
                 },
             ],
         },
         ANSWER: {
-            state: selectedAnswerFilter,
+            state: filter,
             filters: [
                 {
                     id: 1,
-                    name: FilterTexts.ANSWER[1],
+                    name: filterTexts.ANSWER[1],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            filter: { keyword: searchKey, answered: true, tag, team },
-                        })
-                        setSelectedAnswerFilter(FilterTexts.ANSWER[1])
+                        routerHandler(order, filterTexts.ANSWER[1])
                     },
                 },
                 {
                     id: 2,
-                    name: FilterTexts.ANSWER[2],
+                    name: filterTexts.ANSWER[2],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            filter: { keyword: searchKey, answered: false, tag, team },
-                        })
-                        setSelectedAnswerFilter(FilterTexts.ANSWER[2])
+                        routerHandler(order, filterTexts.ANSWER[2])
                     },
                 },
                 {
                     id: 3,
-                    name: FilterTexts.ANSWER[3],
+                    name: filterTexts.ANSWER[3],
                     onClick: () => {
-                        void refetch({
-                            first: 10,
-                            page: 1,
-                            filter: { keyword: searchKey, tag, team },
-                        })
-                        setSelectedAnswerFilter(FilterTexts.ANSWER[3])
-                    },
-                },
-            ],
-        },
-        WATCHED: {
-            state: selectedWatchedFilter,
-            filters: [
-                {
-                    id: 1,
-                    name: FilterTexts.WATCHED[1],
-                    onClick: () => {
-                        setSelectedWatchedFilter(FilterTexts.WATCHED[1])
-                    },
-                },
-                {
-                    id: 2,
-                    name: FilterTexts.WATCHED[2],
-                    onClick: () => {
-                        setSelectedWatchedFilter(FilterTexts.WATCHED[2])
-                    },
-                },
-            ],
-        },
-        POPULAR: {
-            state: selectedPopularFilter,
-            filters: [
-                {
-                    id: 1,
-                    name: FilterTexts.POPULAR[1],
-                    onClick: () => {
-                        setSelectedPopularFilter(FilterTexts.POPULAR[1])
-                    },
-                },
-                {
-                    id: 2,
-                    name: FilterTexts.POPULAR[2],
-                    onClick: () => {
-                        setSelectedPopularFilter(FilterTexts.POPULAR[2])
+                        routerHandler(order, filterTexts.ANSWER[3])
                     },
                 },
             ],
@@ -205,8 +111,8 @@ const DropdownFilters = ({
                 return (
                     <div key={index} className="min-w-[8rem]">
                         <SortDropdown
-                            filters={FilterLists[trigger].filters}
-                            selectedFilter={FilterLists[trigger].state}
+                            filters={filterLists[trigger].filters}
+                            selectedFilter={filterLists[trigger].state}
                         />
                     </div>
                 )

--- a/frontend/components/templates/QuestionsPageLayout.tsx
+++ b/frontend/components/templates/QuestionsPageLayout.tsx
@@ -69,13 +69,7 @@ const QuestionsPageLayout = ({
     const renderSortAndFilter = (): JSX.Element => {
         return (
             <div className="flex gap-2">
-                <DropdownFilters
-                    triggers={['DATE', 'ANSWER']}
-                    searchKey={searchKey}
-                    team={team}
-                    refetch={refetch}
-                    tag={selectedTag}
-                />
+                <DropdownFilters triggers={['DATE', 'ANSWER']} />
             </div>
         )
     }

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -8,6 +8,7 @@ import type { FilterType } from '@/components/templates/QuestionsPageLayout'
 import GET_QUESTION from '@/helpers/graphql/queries/get_question'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { errorNotify } from '@/helpers/toast'
+import type { OrderOption } from '@/pages/questions/'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { Fragment, useState } from 'react'
@@ -93,10 +94,19 @@ type RefetchType = {
     answerSort?: Array<{ column: string; order: string }>
 }
 
+const filterOptions: OrderOption = {
+    'Highest Score': { column: 'VOTES', order: 'DESC' },
+    'Lowest Score': { column: 'VOTES', order: 'ASC' },
+    'Most Recent': { column: 'UPDATED_AT', order: 'DESC' },
+    'Least Recent': { column: 'UPDATED_AT', order: 'ASC' },
+}
+
 const QuestionDetailPage = (): JSX.Element => {
     const router = useRouter()
     const [comment, setComment] = useState(false)
-    const [selectedAnswerFilter, setSelectedAnswerFilter] = useState('Highest Score')
+    const [selectedAnswerFilter, setSelectedAnswerFilter] = useState(
+        String(router.query.answerFilter ?? 'Highest Score')
+    )
 
     const [answer, setAnswer] = useState<AnswerEditType>({ id: null, content: null })
 
@@ -106,9 +116,8 @@ const QuestionDetailPage = (): JSX.Element => {
         variables: {
             slug: String(query.slug),
             shouldAddViewCount: true,
-            answerSort: [{ column: 'VOTES', order: 'DESC' }],
+            answerSort: [filterOptions[selectedAnswerFilter]],
         },
-        fetchPolicy: 'network-only',
     })
 
     if (loading) return loadingScreenShow()
@@ -123,6 +132,13 @@ const QuestionDetailPage = (): JSX.Element => {
         void refetch({ shouldAddViewCount: false })
     }
 
+    const routerHandler = (answerFilter: string): void => {
+        void router.push({
+            pathname: router.pathname,
+            query: { ...router.query, answerFilter },
+        })
+    }
+
     const answerFilters: FilterType[][] = [
         [
             {
@@ -134,6 +150,7 @@ const QuestionDetailPage = (): JSX.Element => {
                         answerSort: [{ column: 'VOTES', order: 'DESC' }],
                     })
                     setSelectedAnswerFilter('Highest Score')
+                    routerHandler('Highest Score')
                 },
             },
             {
@@ -145,6 +162,7 @@ const QuestionDetailPage = (): JSX.Element => {
                         answerSort: [{ column: 'VOTES', order: 'ASC' }],
                     })
                     setSelectedAnswerFilter('Lowest Score')
+                    routerHandler('Lowest Score')
                 },
             },
         ],
@@ -155,9 +173,10 @@ const QuestionDetailPage = (): JSX.Element => {
                 onClick: () => {
                     void refetch({
                         shouldAddViewCount: false,
-                        answerSort: [{ column: 'CREATED_AT', order: 'DESC' }],
+                        answerSort: [{ column: 'UPDATED_AT', order: 'DESC' }],
                     })
                     setSelectedAnswerFilter('Most Recent')
+                    routerHandler('Most Recent')
                 },
             },
             {
@@ -166,9 +185,10 @@ const QuestionDetailPage = (): JSX.Element => {
                 onClick: () => {
                     void refetch({
                         shouldAddViewCount: false,
-                        answerSort: [{ column: 'CREATED_AT', order: 'ASC' }],
+                        answerSort: [{ column: 'UPDATED_AT', order: 'ASC' }],
                     })
                     setSelectedAnswerFilter('Least Recent')
+                    routerHandler('Least Recent')
                 },
             },
         ],

--- a/frontend/pages/questions/index.tsx
+++ b/frontend/pages/questions/index.tsx
@@ -15,29 +15,39 @@ export type RefetchType = {
     sort?: Array<{ column: string; order: string }>
 }
 
+export type OrderOption = Record<string, { column: string; order: string }>
+type FilterOption = Record<string, { answered: boolean }>
+
+export const orderByOptions: OrderOption = {
+    'Newest first': { column: 'CREATED_AT', order: 'DESC' },
+    'Oldest first': { column: 'CREATED_AT', order: 'ASC' },
+    'Most recent': { column: 'UPDATED_AT', order: 'DESC' },
+    'Least recent': { column: 'UPDATED_AT', order: 'ASC' },
+}
+
+export const answerFilterOption: FilterOption = {
+    Answered: { answered: true },
+    Unanswered: { answered: false },
+}
+
 const QuestionsPage = (): JSX.Element => {
     const router = useRouter()
     const [searchKey, setSearchKey] = useState('')
-
     const isSearchResult = router.asPath.includes('/questions?search=')
+    const order = orderByOptions[String(router.query.order ?? 'Newest first')]
+    const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
+
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTIONS, {
         variables: {
             first: 10,
             page: 1,
-            filter: { keyword: searchKey, tag: '' },
-            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
+            filter: { keyword: searchKey, tag: '', ...answerFilter },
+            orderBy: [order],
         },
     })
 
     useEffect(() => {
         setSearchKey(router.query.search as string)
-        refetch({
-            page: 1,
-            filter: { keyword: router.query.search as string, tag: '' },
-            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-        })
-            .then(() => {})
-            .catch(() => {})
     }, [router, searchKey, refetch])
 
     if (loading) return loadingScreenShow()

--- a/frontend/pages/questions/tagged/[slug].tsx
+++ b/frontend/pages/questions/tagged/[slug].tsx
@@ -5,11 +5,13 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { loadingScreenShow } from '../../../helpers/loaderSpinnerHelper'
 import { errorNotify } from '../../../helpers/toast'
-import type { RefetchType } from '../index'
+import { answerFilterOption, orderByOptions, type RefetchType } from '../index'
 
 const TagsPage = (): JSX.Element => {
     const router = useRouter()
     const [selectedTag, setSelectedTag] = useState(router.query.slug as string)
+    const order = orderByOptions[String(router.query.order ?? 'Newest first')]
+    const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTIONS, {
         variables: {
             first: 10,
@@ -25,8 +27,8 @@ const TagsPage = (): JSX.Element => {
         void refetch({
             first: 10,
             page: 1,
-            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-            filter: { tag: selectedTag },
+            orderBy: [order],
+            filter: { tag: selectedTag, ...answerFilter },
         })
         setSelectedTag(slug as string)
     }, [router, selectedTag, refetch])

--- a/frontend/pages/teams/[slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/index.tsx
@@ -8,7 +8,7 @@ import { parseHTML } from '@/helpers/htmlParsing'
 import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import { useBoundStore } from '@/helpers/store'
 import { errorNotify } from '@/helpers/toast'
-import type { RefetchType } from '@/pages/questions'
+import { answerFilterOption, orderByOptions, type RefetchType } from '@/pages/questions'
 import { useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -168,12 +168,14 @@ const Team = (): JSX.Element => {
 const QuestionsTab = (): JSX.Element => {
     const router = useRouter()
     const { slug } = router.query
+    const order = orderByOptions[String(router.query.order ?? 'Newest first')]
+    const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
     const { data, loading, error, refetch } = useQuery<any, RefetchType>(GET_QUESTIONS, {
         variables: {
             first: 10,
             page: 1,
-            orderBy: [{ column: 'CREATED_AT', order: 'DESC' }],
-            filter: { team: slug as string },
+            orderBy: [order],
+            filter: { team: slug as string, ...answerFilter },
         },
     })
 


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-465

## Commands
Go to `Questions` or `Users` or `Tags` Page
Try applying sorting and filters then refresh

## Pre-conditions

## Expected Output
- [x] The selected filters should be retained after refresh/redirect

## Notes

## Screenshots
https://user-images.githubusercontent.com/111732984/233971289-92ea3da4-73bd-4a35-91ac-358cdb7ebdd3.mp4

