### PR TITLE
[Overflow-478] Refactor Admin Teams Page

### DIFF
--- a/backend/graphql/role/query.graphql
+++ b/backend/graphql/role/query.graphql
@@ -4,7 +4,7 @@ extend type Query {
         @hasPermissions(requiredPermission: "view-role")
         @find
     roles: [Role!]! @guard(with: ["api"]) @all
-    rolesPaginate: [Role!]
+    rolesPaginate(orderBy: _ @orderBy(columns: ["updated_at"])): [Role!]
         @guard(with: ["api"])
         @hasPermissions(requiredPermission: "view-role")
         @paginate

--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -31,16 +31,28 @@ type Props = {
 const getButtonClasses = (usage: string, size: string): string => {
     switch (usage) {
         case 'filled':
-            return `items-center font-semibold rounded px-4 py-2 bg-primary-900 text-sm text-white capitalize focus:ring-1 focus:ring-primary-900 focus:bg-primary-900 ${
-                size === 'regular' ? 'h-8' : size === 'medium' ? 'h-9' : 'h-10'
+            return `items-center font-semibold rounded-[5px] px-4 bg-primary-900 text-white capitalize focus:ring-1 focus:ring-primary-900 focus:bg-primary-900 ${
+                size === 'regular'
+                    ? 'font-normal text-xs h-7'
+                    : size === 'medium'
+                    ? 'text-sm h-9 font-semibold'
+                    : 'text-sm h-10 font-semibold'
             }`
         case 'stroke':
-            return `items-center font-semibold rounded px-4 py-2 border bg-neutral-white border-primary-900 text-sm text-primary-900 capitalize focus:ring-1 focus:ring-primary-900 ${
-                size === 'regular' ? 'h-8' : size === 'medium' ? 'h-9' : 'h-10'
+            return `items-center font-semibold rounded-[5px] px-4 border bg-neutral-white border-primary-900 text-primary-900 capitalize focus:ring-1 focus:ring-primary-900 ${
+                size === 'regular'
+                    ? 'font-normal text-xs h-7'
+                    : size === 'medium'
+                    ? 'text-sm h-9 font-semibold'
+                    : 'text-sm h-10 font-semibold'
             }`
         case 'grayed':
-            return `items-center font-semibold rounded px-4 py-2 border bg-neutral-white border-neutral-900 text-sm text-neutral-900 capitalize focus:ring-1 focus:ring-neutral-900 ${
-                size === 'regular' ? 'h-8' : size === 'medium' ? 'h-9' : 'h-10'
+            return `items-center font-semibold rounded-[5px] px-4 border bg-neutral-white border-neutral-900 text-neutral-900 capitalize focus:ring-1 focus:ring-neutral-900 ${
+                size === 'regular'
+                    ? 'font-normal text-xs h-7'
+                    : size === 'medium'
+                    ? 'text-sm h-9 font-semibold'
+                    : 'text-sm h-10 font-semibold'
             }`
         case 'primary':
             return 'items-center rounded-lg border-2 px-5 py-2.5 text-center text-sm font-medium focus:ring-1 text-red-700 border-red-500 focus:ring-red-600 hover:bg-rose-200'

--- a/frontend/components/atoms/InputField/index.tsx
+++ b/frontend/components/atoms/InputField/index.tsx
@@ -41,13 +41,18 @@ const InputField = ({
                 id={name}
                 name={name}
                 value={value}
+<<<<<<< HEAD
                 className={`${
                     additionalClass ?? ''
                 } w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 placeholder-neutral-disabled focus:border-blue-500 focus:ring-blue-500`}
                 placeholder={placeholder ?? ''}
+=======
+                className="w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 focus:border-primary-blue focus:ring-primary-blue"
+                placeholder={label}
+>>>>>>> f7b7966 ([Overflow-478] Refactor Admin Teams Page)
                 onChange={onChange}
             />
-            {!isValid && <span className="ml-2 text-xs text-primary-red">{error}</span>}
+            {!isValid && <span className="ml-2 text-xs text-primary-900">{error}</span>}
         </div>
     )
 }

--- a/frontend/components/atoms/InputField/index.tsx
+++ b/frontend/components/atoms/InputField/index.tsx
@@ -41,15 +41,10 @@ const InputField = ({
                 id={name}
                 name={name}
                 value={value}
-<<<<<<< HEAD
                 className={`${
                     additionalClass ?? ''
                 } w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 placeholder-neutral-disabled focus:border-blue-500 focus:ring-blue-500`}
                 placeholder={placeholder ?? ''}
-=======
-                className="w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 focus:border-primary-blue focus:ring-primary-blue"
-                placeholder={label}
->>>>>>> f7b7966 ([Overflow-478] Refactor Admin Teams Page)
                 onChange={onChange}
             />
             {!isValid && <span className="ml-2 text-xs text-primary-900">{error}</span>}

--- a/frontend/components/atoms/TextArea/index.tsx
+++ b/frontend/components/atoms/TextArea/index.tsx
@@ -27,11 +27,11 @@ const TextArea = ({
                 name={name}
                 rows={rows}
                 value={value}
-                className="w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 focus:border-blue-500 focus:ring-blue-500"
+                className="w-full rounded-md border border-neutral-300 p-2.5 text-sm text-neutral-900 focus:border-primary-blue focus:ring-primary-blue"
                 placeholder={label}
                 onChange={onChange}
             />
-            {!isValid && <span className="ml-2 text-xs text-primary-red">{error}</span>}
+            {!isValid && <span className="ml-2 text-xs text-primary-900">{error}</span>}
         </div>
     )
 }

--- a/frontend/components/molecules/Dropdown/index.tsx
+++ b/frontend/components/molecules/Dropdown/index.tsx
@@ -2,8 +2,8 @@ import type { ControllerRenderProps } from 'react-hook-form'
 import Select, { type CSSObjectWithLabel, type StylesConfig } from 'react-select'
 
 export type OptionType = {
-    id: number
-    name: string
+    value: number
+    label: string
 }
 
 type FormProps = {

--- a/frontend/components/organisms/EditMember/index.tsx
+++ b/frontend/components/organisms/EditMember/index.tsx
@@ -35,7 +35,7 @@ const EditMember = ({
     const [isOpenEdit, setIsOpenEdit] = useState(false)
     const [dropdownErrors, setDropdownErrors] = useState({ role: '' })
     const [updateMember] = useMutation(UPDATE_MEMBER)
-    const defaultRoleId = roles?.find((r) => r.name === role)?.id
+    const defaultRoleId = roles?.find((r) => r.label === role)?.value
 
     const { handleSubmit, reset, control } = useForm<FormValues>({
         mode: 'onSubmit',

--- a/frontend/components/organisms/RoleFormModal/index.tsx
+++ b/frontend/components/organisms/RoleFormModal/index.tsx
@@ -237,6 +237,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                 setModalView(view)
                 closeModal()
                 reset()
+                setFormErrors({ name: '', description: '', permissions: '' })
             }}
             handleSubmit={
                 modalView
@@ -273,12 +274,9 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                             onChange={(e) => {
                                 setRoleName(e.target.value)
                             }}
-                            isValid={formErrors.name.length > 0}
+                            isValid={formErrors.name.length === 0}
                             error={formErrors.name}
                         />
-                        {formErrors.name.length > 0 && (
-                            <span className="ml-2 text-sm text-primary-red">{formErrors.name}</span>
-                        )}
                     </div>
                     <div>
                         <TextArea
@@ -288,15 +286,9 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                             onChange={(e) => {
                                 setRoleDescription(e.target.value)
                             }}
-                            isValid={formErrors.name.length > 0}
-                            error={formErrors.name}
+                            isValid={formErrors.description.length === 0}
+                            error={formErrors.description}
                         />
-
-                        {formErrors.description.length > 0 && (
-                            <span className="text-sm text-primary-red">
-                                {formErrors.description}
-                            </span>
-                        )}
                     </div>
                     <div>
                         <div className="text-neutral-800 text-sm font-medium">Set Permissions</div>
@@ -304,7 +296,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                             {renderPermissionSelection()}
                         </div>
                         {formErrors.permissions.length > 0 && (
-                            <span className="mb-2 text-sm text-primary-red">
+                            <span className="mb-2 text-xs text-primary-900">
                                 {formErrors.permissions}
                             </span>
                         )}

--- a/frontend/components/organisms/Table/index.tsx
+++ b/frontend/components/organisms/Table/index.tsx
@@ -29,7 +29,7 @@ const renderClickable = (
     }
     return (
         <span
-            className="text-l cursor-pointer text-left font-semibold text-gray-800 hover:text-primary-red"
+            className="cursor-pointer text-left text-xs font-semibold text-neutral-900 hover:text-primary-900"
             onClick={handleClick}
         >
             {text}
@@ -46,10 +46,10 @@ const Table = ({
     clickableArr = [],
 }: TableProps): JSX.Element => {
     return (
-        <div className="max-w-[960px] place-self-center overflow-hidden rounded-md pt-4">
+        <div className="max-w-[960px] place-self-center overflow-hidden rounded-md">
             <div className="relative overflow-x-auto border-2 shadow-md sm:rounded-lg">
-                <table className="w-full text-left text-sm">
-                    <thead className="bg-primary-200 font-semibold uppercase text-neutral-900">
+                <table className="w-full text-left">
+                    <thead className="bg-primary-200 uppercase text-neutral-900">
                         <tr>
                             {columns.map((column) => (
                                 <th
@@ -58,7 +58,7 @@ const Table = ({
                                     style={{
                                         width: column.width,
                                     }}
-                                    className="p-4"
+                                    className="space-x-4 p-4 text-sm font-semibold"
                                 >
                                     {column.title}
                                 </th>
@@ -79,20 +79,24 @@ const Table = ({
                                             )
                                             if (column.key === 'action' && actions) {
                                                 return (
-                                                    <td key={key} className="p-4">
+                                                    <td key={key} className="items-center p-4">
                                                         {actions(Number(data.key))}
                                                     </td>
                                                 )
                                             }
                                             return (
                                                 <td key={key} className="whitespace-nowrap p-4">
-                                                    {clickable !== undefined
-                                                        ? renderClickable(
-                                                              data[column.key],
-                                                              clickable,
-                                                              data.slug as string
-                                                          )
-                                                        : data[column.key]}
+                                                    {clickable !== undefined ? (
+                                                        renderClickable(
+                                                            data[column.key],
+                                                            clickable,
+                                                            data.slug as string
+                                                        )
+                                                    ) : (
+                                                        <span className="text-left text-xs font-normal text-neutral-900">
+                                                            {data[column.key]}
+                                                        </span>
+                                                    )}
                                                 </td>
                                             )
                                         })}

--- a/frontend/components/organisms/TeamsFormModal/index.tsx
+++ b/frontend/components/organisms/TeamsFormModal/index.tsx
@@ -9,7 +9,6 @@ import { loadingScreenShow } from '@/helpers/loaderSpinnerHelper'
 import type { UserType } from '@/pages/questions/[slug]'
 import type { FetchResult } from '@apollo/client'
 import { useMutation, useQuery } from '@apollo/client'
-import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { errorNotify, successNotify } from '../../../helpers/toast'
@@ -35,7 +34,6 @@ type FormValues = {
 }
 
 const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps): JSX.Element => {
-    const router = useRouter()
     const [formErrors, setFormErrors] = useState({
         teamName: '',
         teamLeader: '',
@@ -50,7 +48,7 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
     const teamLeaders: OptionType[] = data?.teamLeaders.map(
         ({ id, first_name, last_name }: UserType) =>
             ({
-                value: id,
+                value: id ? +id : 0,
                 label: `${first_name ?? ''} ${last_name ?? ''}`,
             } ?? [])
     )
@@ -126,7 +124,6 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
                     .then(({ data }: FetchResult<{ updateTeam: { id: number; slug: string } }>) => {
                         successNotify('Team updated successfully')
                         refetch()
-                        void router.push(`teams/${data?.updateTeam.slug ?? ''}`)
                     })
                     .catch(() => {
                         errorNotify('Error updating team')
@@ -146,7 +143,6 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
                     .then(({ data }: FetchResult<{ createTeam: { id: number; slug: string } }>) => {
                         successNotify('Team created successfully')
                         refetch()
-                        void router.push(`teams/${data?.createTeam.slug ?? ''}`)
                     })
                     .catch(() => {
                         errorNotify('Error creating team')

--- a/frontend/components/templates/MemberManage.tsx
+++ b/frontend/components/templates/MemberManage.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import BackButton from '../atoms/BackButton'
+import type { RoleType } from '../organisms/RoleFormModal'
 
 interface IMember {
     id: number
@@ -34,8 +35,8 @@ interface IMember {
 }
 
 type FormValues = {
-    user: number
-    role: number
+    user: OptionType
+    role: OptionType
 }
 
 const columns: ColumnType[] = [
@@ -124,13 +125,13 @@ const MemberManage = ({ isForAdmin = false }: Props): JSX.Element => {
     }
 
     const users: OptionType[] = usersData.data?.allUsers.map((user: UserType) => ({
-        id: user.id,
-        name: `${user.first_name ?? ''} ${user.last_name ?? ''}`,
+        value: user.id,
+        label: `${user.first_name ?? ''} ${user.last_name ?? ''}`,
     }))
 
-    const roles: OptionType[] = teamRoles.data?.teamRoles.map((role: OptionType) => ({
-        id: role.id,
-        name: role.name,
+    const roles: OptionType[] = teamRoles.data?.teamRoles.map((role: RoleType) => ({
+        value: role.id,
+        label: role.name,
     }))
 
     const openModal = (modal: string): void => {
@@ -242,7 +243,7 @@ const MemberManage = ({ isForAdmin = false }: Props): JSX.Element => {
                                     <Controller
                                         control={control}
                                         name="user"
-                                        defaultValue={users.length && users[0].id}
+                                        defaultValue={{ value: 0, label: '' }}
                                         render={({ field: { onChange, value } }) => (
                                             <Dropdown
                                                 key="user-select"
@@ -265,7 +266,7 @@ const MemberManage = ({ isForAdmin = false }: Props): JSX.Element => {
                                     <Controller
                                         control={control}
                                         name="role"
-                                        defaultValue={roles[0].id}
+                                        defaultValue={{ value: 0, label: '' }}
                                         render={({ field: { onChange, value } }) => (
                                             <Dropdown
                                                 key="role-select"

--- a/frontend/pages/manage/roles/index.tsx
+++ b/frontend/pages/manage/roles/index.tsx
@@ -18,7 +18,7 @@ const columns: ColumnType[] = [
     {
         title: 'Role',
         key: 'name',
-        width: 144,
+        width: 240,
     },
     {
         title: 'Description',
@@ -28,7 +28,7 @@ const columns: ColumnType[] = [
     {
         title: 'Actions',
         key: 'action',
-        width: 20,
+        width: 128,
     },
 ]
 
@@ -46,14 +46,14 @@ const ViewRole = ({ role, refetch }: { role: RolesType; refetch: () => void }): 
     const [showModal, setShowModal] = useState(false)
 
     return (
-        <div>
+        <>
             <Button
                 usage="toggle-modal"
                 onClick={() => {
                     setShowModal(true)
                 }}
             >
-                <Icons name="eye" />
+                <Icons name="eye" size="18" />
             </Button>
             <RoleFormModal
                 role={role}
@@ -64,7 +64,7 @@ const ViewRole = ({ role, refetch }: { role: RolesType; refetch: () => void }): 
                 }}
                 refetch={refetch}
             />
-        </div>
+        </>
     )
 }
 
@@ -72,14 +72,14 @@ const EditRole = ({ role, refetch }: { role: RolesType; refetch: () => void }): 
     const [showModal, setShowModal] = useState(false)
 
     return (
-        <div>
+        <>
             <Button
                 usage="toggle-modal"
                 onClick={() => {
                     setShowModal(true)
                 }}
             >
-                <Icons name="pencil" />
+                <Icons name="pencil" size="18" />
             </Button>
             <RoleFormModal
                 role={role}
@@ -90,7 +90,7 @@ const EditRole = ({ role, refetch }: { role: RolesType; refetch: () => void }): 
                 }}
                 refetch={refetch}
             />
-        </div>
+        </>
     )
 }
 
@@ -125,14 +125,14 @@ const DeleteRole = ({
     }
 
     return (
-        <div>
+        <>
             <Button
                 usage="toggle-modal"
                 onClick={() => {
                     setShowModal(true)
                 }}
             >
-                <Icons name="trash" />
+                <Icons name="trash" size="18" />
             </Button>
             <Modal
                 title="Delete Role"
@@ -147,7 +147,7 @@ const DeleteRole = ({
                     Are you sure you wish to delete <span className="font-bold">{name}</span>?
                 </span>
             </Modal>
-        </div>
+        </>
     )
 }
 
@@ -201,7 +201,7 @@ const RolesPage = (): JSX.Element => {
 
         if (role) {
             return (
-                <div className="flex flex-row gap-4">
+                <div className="flex flex-row items-center gap-4">
                     <ViewRole
                         role={role}
                         refetch={async () => {
@@ -256,8 +256,8 @@ const RolesPage = (): JSX.Element => {
     }
 
     return (
-        <div className="flex flex-col items-center p-4">
-            <div className="flex h-full flex-col py-4">
+        <div className="flex flex-col items-center">
+            <div className="flex h-full flex-col gap-4">
                 <div className="flex items-center justify-end">
                     <Button
                         usage="stroke"

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -22,7 +22,11 @@ type TeamType = {
     members_count: string
     truncated_name: string
     truncated_description: string
-    teamLeader: { id: number }
+    teamLeader: {
+        id: number
+        first_name: string
+        last_name: string
+    }
 }
 
 type TeamsQuery = {
@@ -36,40 +40,43 @@ const columns: ColumnType[] = [
     {
         title: 'Team Name',
         key: 'name',
+        width: 240,
     },
     {
         title: 'Description',
         key: 'description',
+        width: 500,
     },
     {
         title: 'Members',
         key: 'members_count',
+        width: 96,
     },
     {
-        title: '',
+        title: 'Actions',
         key: 'action',
-        width: 20,
+        width: 96,
     },
 ]
 
 const EditAction = ({ team, refetch }: { team?: DataType; refetch: () => void }): JSX.Element => {
     const [showModal, setShowModal] = useState(false)
-
     return (
-        <div>
+        <>
             <Button
                 usage="toggle-modal"
                 onClick={() => {
                     setShowModal(true)
                 }}
             >
-                <Icons name="table_edit" />
+                <Icons name="pencil" size="18" />
             </Button>
             <TeamsFormModal
                 initialData={{
                     id: team?.key as number,
                     title: team?.full_name as string,
                     teamLeaderId: team?.teamLeaderId as number,
+                    teamLeaderName: team?.teamLeaderName as string,
                     description: team?.full_description as string,
                 }}
                 isOpen={showModal}
@@ -78,7 +85,7 @@ const EditAction = ({ team, refetch }: { team?: DataType; refetch: () => void })
                 }}
                 refetch={refetch}
             />
-        </div>
+        </>
     )
 }
 const DeleteAction = ({
@@ -108,14 +115,14 @@ const DeleteAction = ({
     }
 
     return (
-        <div>
+        <>
             <Button
                 usage="toggle-modal"
                 onClick={() => {
                     setShowModal(true)
                 }}
             >
-                <Icons name="table_delete" additionalClass="fill-gray-500" />
+                <Icons name="trash" size="18" />
             </Button>
             <Modal
                 title="Delete Team"
@@ -130,7 +137,7 @@ const DeleteAction = ({
                     Are you sure you wish to delete <span className="font-bold">{name}</span>?
                 </span>
             </Modal>
-        </div>
+        </>
     )
 }
 
@@ -191,13 +198,14 @@ const AdminTeams = (): JSX.Element => {
                 description,
                 truncated_description,
                 members_count,
-                teamLeader: { id: teamLeaderId },
+                teamLeader: { id: teamLeaderId, first_name, last_name },
             } = team
             return {
                 key: id,
                 slug,
                 members_count,
                 teamLeaderId: +teamLeaderId,
+                teamLeaderName: `${first_name} ${last_name}`,
                 name: truncated_name,
                 description: truncated_description,
                 full_name: name,
@@ -210,7 +218,7 @@ const AdminTeams = (): JSX.Element => {
         const team = getTeamDataTable(teamArr).find((team) => +team.key === key)
 
         return (
-            <div className="flex flex-row gap-4">
+            <div className="flex flex-row items-center gap-4">
                 <EditAction
                     team={team}
                     refetch={async () => {
@@ -237,30 +245,39 @@ const AdminTeams = (): JSX.Element => {
         )
     }
 
-    return (
-        <div className="flex flex-col">
-            <div className="flex w-full flex-row items-center justify-between">
-                <h1 className="text-3xl font-bold text-gray-800">Teams</h1>
-                <Button
-                    type="button"
-                    additionalClass="px-6 py-3"
-                    onClick={() => {
-                        setShowModal(true)
-                    }}
-                >
-                    New Team
-                </Button>
-            </div>
+    const renderFooter = (): JSX.Element | null => {
+        if (paginatorInfo.lastPage > 1) {
+            return (
+                <div className="flex w-full items-center justify-center">
+                    <Paginate {...paginatorInfo} onPageChange={onPageChange} />
+                </div>
+            )
+        }
+        return null
+    }
 
-            <Table
-                columns={columns}
-                dataSource={getTeamDataTable(teamArr)}
-                isEmptyString="No Teams to Show"
-                actions={renderTeamsActions}
-                clickableArr={clickableArr}
-            />
-            <div className="mt-auto">
-                <Paginate {...paginatorInfo} onPageChange={onPageChange} />
+    return (
+        <div className="flex flex-col items-center">
+            <div className="flex h-full flex-col gap-4">
+                <div className="flex items-center justify-end">
+                    <Button
+                        usage="stroke"
+                        size="large"
+                        onClick={() => {
+                            setShowModal(true)
+                        }}
+                    >
+                        Add Team
+                    </Button>
+                </div>
+                <Table
+                    columns={columns}
+                    dataSource={getTeamDataTable(teamArr)}
+                    isEmptyString="No Teams to Show"
+                    actions={renderTeamsActions}
+                    clickableArr={clickableArr}
+                    footer={renderFooter()}
+                />
             </div>
             <TeamsFormModal
                 isOpen={showModal}

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -160,7 +160,7 @@ const AdminUsers = (): JSX.Element => {
                     })
                 }}
             >
-                <Icons name="pencil" />
+                <Icons name="pencil" size="18" />
             </Button>
         )
     }
@@ -198,8 +198,8 @@ const AdminUsers = (): JSX.Element => {
     }
 
     return (
-        <div className="flex w-full flex-col p-4">
-            <div className="flex h-full flex-col py-4">
+        <div className="flex w-full flex-col">
+            <div className="flex h-full flex-col gap-4">
                 <Table
                     columns={columns}
                     dataSource={newUserArr}


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-478
https://framgiaph.backlog.com/view/SUN_OVERFLOW-473

## Commands
none

## Pre-conditions
You should be an admin to access these pages.

## Expected Output

- [x] You should see the new design for Admin Teams page
- [x] You should be able to see options for Team Leader select 

## Notes
- Included fix for accessing roles page
- Included bugfix to show options for select team leader
- Updated table font sizes 

Affected pages:
- Manage Teams
- Manage Roles
- Manage Users 

- Did not include the Admin Team Detail page yet since it is dependent on another task

## Screenshots
![image](https://user-images.githubusercontent.com/116238730/234519655-a4f96b2f-5ccb-4d72-8f40-520512776609.png)
![image](https://user-images.githubusercontent.com/116238730/234740061-448c966e-e0a3-4674-86d7-df6c1bf5537d.png)


