### PR TITLE
[Overflow-471] [Bugfix] Admin accessing users and teams not exist

### DIFF
--- a/frontend/pages/manage/teams/[slug]/index.tsx
+++ b/frontend/pages/manage/teams/[slug]/index.tsx
@@ -35,6 +35,7 @@ const getActiveTabClass = (status: boolean): string => {
 const TeamDetail = (): JSX.Element => {
     const router = useRouter()
     const [activeTab, setActiveTab] = useState<string>('Questions')
+    const [verified, setVerified] = useState<boolean>(false)
 
     const { slug } = router.query
     const questionsApi = useQuery<any, RefetchType>(GET_QUESTIONS, {
@@ -48,12 +49,19 @@ const TeamDetail = (): JSX.Element => {
 
     const { data, loading, error } = useQuery(GET_TEAM, {
         variables: { slug },
+        async onCompleted(data) {
+            if (data.team === null) {
+                errorNotify('Team does not exist')
+                await router.replace('/manage/teams')
+            }
+            setVerified(true)
+        },
     })
 
     const team: TeamType = data?.team
     const teamLeader: UserType = team?.teamLeader
 
-    if (loading || questionsApi.loading) return loadingScreenShow()
+    if (loading || questionsApi.loading || !verified) return loadingScreenShow()
     if (error) {
         return <span>{errorNotify(`Error! ${error.message}`)}</span>
     }

--- a/frontend/pages/manage/users/[slug]/index.tsx
+++ b/frontend/pages/manage/users/[slug]/index.tsx
@@ -26,7 +26,6 @@ const UserDetail = (): JSX.Element => {
     const activeTab = (router.query.tab ?? 'Questions') as Tab
     const order = orderByOptions[String(router.query.order ?? 'Newest first')]
     const answerFilter = answerFilterOption[String(router.query.filter ?? '')]
-
     const {
         userData,
         userQuestions,
@@ -40,6 +39,11 @@ const UserDetail = (): JSX.Element => {
     } = useTabData(activeTab, view)
 
     if (loading) return loadingScreenShow()
+    if (userData.user === null) {
+        errorNotify('User does not exist')
+        void router.replace('/manage/users')
+        return loadingScreenShow()
+    }
     if (error) {
         return <>{errorNotify(`Error! ${error?.message ?? ''}`)}</>
     }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-471
## Commands

## Pre-conditions

## Expected Output
* If user does not exist when accessing `/manage/users/slug` redirect to `/manage/users`
* If team does not exist when accessing `/manage/teams/slug` redirect to `/manage/teams`
## Notes

## Screenshots
