### PR TITLE
[Overflow-470] [Bugfix] Users accessing questions, users, and teams not exist

### DIFF
--- a/frontend/components/templates/Profile.tsx
+++ b/frontend/components/templates/Profile.tsx
@@ -74,13 +74,13 @@ const ProfileLayout = ({ data, toggleFollow, isPublic }: ProfileLayoutProps): JS
 
     const renderActivities = (): JSX.Element => {
         return (
-            <div className=" w-full space-y-4  bg-white pb-4 drop-shadow-md">
+            <div className="flex w-full flex-grow flex-col space-y-4  bg-white pb-4 drop-shadow-md">
                 <div className="bg-primary-200  p-2 font-semibold leading-6">ACTIVITY</div>
                 <div className="space-y-4 px-2">
                     <div className="space-y-4 p-4">
                         <div className="font-semibold leading-[145%]">Top Questions</div>
                         {data.top_questions.length === 0 ? (
-                            <div className="py-2 text-center text-primary-gray">
+                            <div className="w-full py-2 text-center text-primary-gray">
                                 No Top Questions to Show
                             </div>
                         ) : (
@@ -205,7 +205,7 @@ const ProfileLayout = ({ data, toggleFollow, isPublic }: ProfileLayoutProps): JS
                     handleFollowing={handleFollowing}
                     handleEditModal={handleEdit}
                 />
-                <div className="flex flex-shrink flex-col space-y-4">
+                <div className="flex w-full flex-col space-y-4">
                     {renderActivities()}
                     {renderBookmarks()}
                 </div>

--- a/frontend/components/templates/Profile.tsx
+++ b/frontend/components/templates/Profile.tsx
@@ -57,7 +57,6 @@ type ProfileLayoutProps = {
 }
 
 const ProfileLayout = ({ data, toggleFollow, isPublic }: ProfileLayoutProps): JSX.Element => {
-    console.log(data)
     const [isOpenFollower, setIsOpenFollower] = useState<boolean>(false)
     const [isOpenFollowing, setIsOpenFollowing] = useState<boolean>(false)
     const [isOpenEdit, setIsOpenEdit] = useState<boolean>(false)

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -121,7 +121,12 @@ const QuestionDetailPage = (): JSX.Element => {
     })
 
     if (loading) return loadingScreenShow()
-    else if (error) return <span>{errorNotify(`Error! ${error.message}`)}</span>
+    if (error) {
+        errorNotify('Question not Found')
+        void router.replace('/404')
+        return loadingScreenShow()
+    }
+    console.log(data)
     const question: QuestionType = {
         ...data.question,
     }

--- a/frontend/pages/questions/[slug]/index.tsx
+++ b/frontend/pages/questions/[slug]/index.tsx
@@ -126,7 +126,6 @@ const QuestionDetailPage = (): JSX.Element => {
         void router.replace('/404')
         return loadingScreenShow()
     }
-    console.log(data)
     const question: QuestionType = {
         ...data.question,
     }

--- a/frontend/pages/teams/[slug]/index.tsx
+++ b/frontend/pages/teams/[slug]/index.tsx
@@ -59,7 +59,16 @@ const Team = (): JSX.Element => {
     }, [router, refetch])
 
     if (loading) return loadingScreenShow()
-    else if (error) return <span>{errorNotify(`Error! ${error.message}`)}</span>
+    if (error) {
+        errorNotify(`Error! ${error.message}`)
+        void router.push('/404')
+        return loadingScreenShow()
+    }
+    if (data.team === null) {
+        errorNotify(`Team does not exist`)
+        void router.push('/404')
+        return loadingScreenShow()
+    }
 
     const getActiveTabClass = (status: boolean): string => {
         if (status) {

--- a/frontend/pages/users/[slug].tsx
+++ b/frontend/pages/users/[slug].tsx
@@ -24,12 +24,12 @@ const Profile = (): JSX.Element => {
     if (error) {
         errorNotify(`Error! ${error.message}`)
         void router.push('/404')
-        return <></>
+        return loadingScreenShow()
     }
     if (data.user === null) {
         errorNotify(`User does not exist`)
         void router.push('/404')
-        return <></>
+        return loadingScreenShow()
     }
 
     const isPublic = userSlug !== router.query.slug


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-470

## Commands

## Pre-conditions

## Expected Output
* If user does not exist when accessing `/users/slug` redirect to `/404`
* If team does not exist when accessing `/teams/slug` redirect to `/404`
* If question does not exist when accessing `/questions/slug` redirect to `/404`

## Notes
* Some Fixes for User Profile 
## Screenshots
