### PR TITLE
[Overflow-488] [Bugfix] Page Refresh on Submit

### DIFF
--- a/frontend/components/organisms/RoleFormModal/index.tsx
+++ b/frontend/components/organisms/RoleFormModal/index.tsx
@@ -136,6 +136,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
     }
 
     const onSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+        e.preventDefault()
         const target = e.target as typeof e.target & {
             name: { value: string }
             description: { value: string }

--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -33,6 +33,7 @@ const TagsFormModal = ({
     const [updateTag] = useMutation(UPDATE_TAG)
 
     const onSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+        e.preventDefault()
         const target = e.target as typeof e.target & {
             tagName: { value: string }
             tagDescription: { value: string }


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-488
## Commands

## Pre-conditions

## Expected Output
* Sending form does not refresh page for `/manage/tags` and `/manage/roles`
## Notes

## Screenshots
