### PR TITLE
[OVERFLOW-514] Profile images should be only one per user

### DIFF
--- a/backend/app/GraphQL/Mutations/CreateTeam.php
+++ b/backend/app/GraphQL/Mutations/CreateTeam.php
@@ -3,7 +3,6 @@
 namespace App\GraphQL\Mutations;
 
 use App\Exceptions\CustomException;
-use App\Models\Member;
 use App\Models\Team;
 use App\Models\User;
 use Exception;

--- a/backend/app/GraphQL/Mutations/UpdateUser.php
+++ b/backend/app/GraphQL/Mutations/UpdateUser.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Exceptions\CustomException;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 
 final class UpdateUser
@@ -12,7 +13,7 @@ final class UpdateUser
      * @param  null  $_
      * @param  array{}  $args
      */
-    public function uploadAvatar($avatar, $email, $path = 'avatar')
+    public function uploadAvatar($avatar, $email, $path, $previousAvatar)
     {
         if (! $avatar) {
             return null;
@@ -24,6 +25,11 @@ final class UpdateUser
 
         if (! file_exists($storagePath)) {
             mkdir($storagePath, 0777, true);
+        }
+
+        if (str_contains($previousAvatar, URL::to('/').'/storage/avatar/')) {
+            $parsePreviousAvatar = explode(URL::to('/').'/storage/avatar/', $previousAvatar);
+            Storage::delete("/public/$path/".$parsePreviousAvatar[1]);
         }
 
         file_put_contents($storagePath.$fileName, $data);
@@ -52,7 +58,7 @@ final class UpdateUser
             'last_name' => $args['last_name'],
             'about_me' => $args['about_me'],
             'avatar' => str_contains($args['avatar'], 'base64') ?
-                $this->uploadAvatar($args['avatar'], $user->email) : $user->avatar,
+                $this->uploadAvatar($args['avatar'], $user->email, 'avatar', $user->avatar) : $user->avatar,
         ]);
 
         return $user;

--- a/backend/app/Observers/TeamObserver.php
+++ b/backend/app/Observers/TeamObserver.php
@@ -14,9 +14,10 @@ class TeamObserver
         $team->members()->create([
             'user_id' => $team->user_id,
             'team_id' => $team->id,
-            'team_role_id' => 1
+            'team_role_id' => 1,
         ]);
     }
+
     public function deleting(Team $team)
     {
         Member::where('team_id', $team->id)->delete();


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-514
## Commands
none
## Pre-conditions
none
## Expected Output
When updating profile image , images in storage folder should not be duplicated 
## Notes
None
## Screenshots
None