### PR TITLE
[Overflow-498] [Bugfix] Profile Picture does not update

### DIFF
--- a/frontend/components/molecules/UserDropdown/index.tsx
+++ b/frontend/components/molecules/UserDropdown/index.tsx
@@ -33,6 +33,8 @@ const UserDropdown = ({
                         name={`${first_name} ${last_name}`}
                         size="36"
                         alt={first_name}
+                        maxInitials={1}
+                        textSizeRatio={2}
                         src={
                             updated_at && updated_at.length > 0
                                 ? `${avatar}?${updated_at}`

--- a/frontend/components/organisms/EditProfileModal/index.tsx
+++ b/frontend/components/organisms/EditProfileModal/index.tsx
@@ -153,7 +153,9 @@ const EditProfileModal = ({
                         <div className="flex w-full flex-col items-center align-middle">
                             <Avatar
                                 round
+                                name={`${firstName} ${lastName}`}
                                 src={watch('avatar')}
+                                alt={firstName}
                                 maxInitials={1}
                                 textSizeRatio={2}
                                 className="object-cover"


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-498
## Commands

## Pre-conditions

## Expected Output
* Same Alt image for ProfileCard, UserDropdown, and EditProfile
## Notes
* Image not changing was due to http -> https which produces mixed content

## Screenshots
![image](https://user-images.githubusercontent.com/114897466/236107364-52cbdc09-7c07-4e5c-bcb5-842d6cd13e82.png)
