### PR TITLE
[Overflow-492] [BUGFIX] Table width adjusts on pagination click

### DIFF
--- a/frontend/components/organisms/RoleFormModal/index.tsx
+++ b/frontend/components/organisms/RoleFormModal/index.tsx
@@ -272,6 +272,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                             name="name"
                             value={roleName}
                             label="Role Name"
+                            placeholder="Role Name"
                             onChange={(e) => {
                                 setRoleName(e.target.value)
                             }}
@@ -283,7 +284,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                         <TextArea
                             name="description"
                             value={roleDescription}
-                            label="Description"
+                            label="Role Description"
                             onChange={(e) => {
                                 setRoleDescription(e.target.value)
                             }}

--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -125,9 +125,9 @@ const TagsFormModal = ({
             <form className="flex w-full flex-col gap-4 " onSubmit={onSubmit}>
                 <InputField
                     name="tagName"
-                    label="Name"
+                    label="Tag Name"
                     value={tagName}
-                    placeholder="Name"
+                    placeholder="Tag Name"
                     onChange={(e) => {
                         setTagName(e.target.value)
                     }}
@@ -137,7 +137,7 @@ const TagsFormModal = ({
                 <TextArea
                     name="tagDescription"
                     value={tagDescription}
-                    label="Description"
+                    label="Tag Description"
                     onChange={(e) => {
                         setTagDescription(e.target.value)
                     }}

--- a/frontend/components/organisms/TeamsFormModal/index.tsx
+++ b/frontend/components/organisms/TeamsFormModal/index.tsx
@@ -181,6 +181,7 @@ const TeamsFormModal = ({ initialData, isOpen, closeModal, refetch }: FormProps)
                             <InputField
                                 name="teamName"
                                 label="Team Name"
+                                placeholder="Team Name"
                                 value={value}
                                 onChange={onChange}
                                 isValid={formErrors.teamName.length === 0}

--- a/frontend/pages/manage/roles/index.tsx
+++ b/frontend/pages/manage/roles/index.tsx
@@ -161,7 +161,7 @@ const RolesPage = (): JSX.Element => {
         refetch,
     } = useQuery(GET_ROLES_PAGINATE, {
         variables: {
-            first: 10,
+            first: 6,
             page: 1,
         },
         fetchPolicy: 'network-only',
@@ -169,7 +169,7 @@ const RolesPage = (): JSX.Element => {
 
     useEffect(() => {
         void refetch({
-            first: 10,
+            first: 6,
             page: 1,
         })
     }, [refetch])

--- a/frontend/pages/manage/users/index.tsx
+++ b/frontend/pages/manage/users/index.tsx
@@ -19,18 +19,22 @@ const columns: ColumnType[] = [
     {
         title: 'Name',
         key: 'name',
+        width: 240,
     },
     {
         title: 'Questions',
         key: 'question_count',
+        width: 112,
     },
     {
         title: 'Answers',
         key: 'answer_count',
+        width: 112,
     },
     {
         title: 'Role',
         key: 'role',
+        width: 240,
     },
     {
         title: 'Actions',


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-492

## Commands
none

## Pre-conditions
none

## Expected Output

- [x] Tables doesn't change width after pagination click

## Notes
- Included updates for inconsistencies in modal forms

## Screenshots
[Screencast 2023-05-05 11-22-15.webm](https://user-images.githubusercontent.com/116238730/236371654-6a001834-a5ea-4ae0-8d71-5ff1aaca3d43.webm)
