### PR TITLE
[Overflow-502] [BUGFIX] User page filters cannot be reset

### DIFF
--- a/frontend/pages/users/index.tsx
+++ b/frontend/pages/users/index.tsx
@@ -104,8 +104,8 @@ const UsersPage = (): JSX.Element => {
                 variables: {
                     first: 12,
                     page: 1,
-                    filter: { keyword: '', role_id: null },
-                    sort: { reputation: null },
+                    filter: { keyword: '', role_id: selectedRole.id },
+                    sort: { reputation: selectedScore.sort },
                 },
             })
             setTerm('')
@@ -132,6 +132,22 @@ const UsersPage = (): JSX.Element => {
             setSelectedRole({ id: role.id, label: role.name })
         },
     }))
+
+    roleFilters.unshift({
+        id: 0,
+        name: 'All Users',
+        onClick: async () => {
+            await refetch({
+                first: 12,
+                page: 1,
+                filter: { keyword: searchKey },
+                sort: { reputation: selectedScore.sort },
+            })
+            delete router.query.role
+            void router.replace(router.query)
+            setSelectedRole({ id: null, label: 'All Users' })
+        },
+    })
 
     const scoreSort = [
         {


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-502

## Commands
none

## Pre-conditions
none

## Expected Output

- [x] You should be able to select _All Users_ from the Roles filter

## Notes

## Screenshots
[Screencast 2023-05-05 16-08-06.webm](https://user-images.githubusercontent.com/116238730/236407989-e37d89fb-e803-45ad-9593-76eed4eae542.webm)
