### PR TITLE
[Overflow-461] [BUGFIX] Handle modal button states

### DIFF
--- a/frontend/components/atoms/Button/index.tsx
+++ b/frontend/components/atoms/Button/index.tsx
@@ -37,11 +37,11 @@ const getButtonClasses = (usage: string, size: string): string => {
                 size === 'regular' ? 'font-normal text-xs h-7' : 'text-sm h-9 font-semibold'
             }`
         case 'stroke':
-            return `items-center rounded-[5px] px-4 border bg-neutral-white border-primary-900 text-primary-900 capitalize focus:ring-1 focus:ring-primary-900 ${
+            return `items-center rounded-[5px] px-4 border bg-neutral-white border-primary-900 text-primary-900 capitalize focus:ring-1 focus:ring-primary-900 hover:bg-primary-200 outline-none ${
                 size === 'regular' ? 'font-normal text-xs h-7' : 'text-sm h-9 font-semibold'
             }`
         case 'grayed':
-            return `items-center rounded-[5px] px-4 border bg-neutral-white border-neutral-900 text-neutral-900 capitalize focus:ring-1 focus:ring-neutral-900 ${
+            return `items-center rounded-[5px] px-4 border bg-neutral-white border-neutral-900 text-neutral-900 capitalize focus:ring-1 focus:ring-neutral-900 hover:bg-neutral-200 ${
                 size === 'regular' ? 'font-normal text-xs h-7' : 'text-sm h-9 font-semibold'
             }`
         case 'primary':

--- a/frontend/components/atoms/Icons/Loading.tsx
+++ b/frontend/components/atoms/Icons/Loading.tsx
@@ -1,0 +1,30 @@
+import { TailSpin } from 'react-loader-spinner'
+
+type LoadingProps = {
+    height?: number
+    width?: number
+    color?: string
+    additionalClass?: string
+}
+
+const Loading = ({
+    width = 20,
+    height = 20,
+    color = '#FF2200',
+    additionalClass = '',
+}: LoadingProps): JSX.Element => {
+    return (
+        <TailSpin
+            height={width}
+            width={height}
+            color={color}
+            ariaLabel="tail-spin-loading"
+            radius="1"
+            wrapperStyle={{}}
+            wrapperClass={additionalClass}
+            visible={true}
+        />
+    )
+}
+
+export default Loading

--- a/frontend/components/atoms/Icons/index.tsx
+++ b/frontend/components/atoms/Icons/index.tsx
@@ -26,6 +26,7 @@ import EyeIcon from './Eye'
 import FilterIcon from './Filter'
 import GridIcon from './Grid'
 import ListIcon from './List'
+import LoadingSpinner from './Loading'
 import LockIcon from './Lock'
 import SearchIcon from './Search'
 import ThumbUpIcon from './ThumbUp'
@@ -127,6 +128,7 @@ const Icons = ({ name, size = '20', additionalClass = '' }: IconsProps): JSX.Ele
 }
 
 export const CustomIcons = {
+    LoadingSpinner,
     ChevronIcon,
     DotsIcon,
     EyeIcon,

--- a/frontend/components/organisms/RoleFormModal/index.tsx
+++ b/frontend/components/organisms/RoleFormModal/index.tsx
@@ -36,6 +36,7 @@ type Props = {
 }
 
 const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Props): JSX.Element => {
+    const [modalButtonLoading, setModalButtonLoading] = useState(false)
     const [permissionsForm, setPermissionsForm] = useState<number[]>([])
     const [selectedPermissions, setSelectedPermissions] = useState<number[]>([])
     const [roleName, setRoleName] = useState(role?.name ?? '')
@@ -174,8 +175,8 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                     role.description === description
                 ) {
                     errorNotify('No changes were made!')
-                    closeModal()
                 } else {
+                    setModalButtonLoading(true)
                     updateRole({
                         variables: {
                             id: role.id,
@@ -193,8 +194,14 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                         .catch((e) => {
                             errorNotify(e.message)
                         })
+                        .finally(() => {
+                            setTimeout(() => {
+                                setModalButtonLoading(false)
+                            }, 500)
+                        })
                 }
             } else {
+                setModalButtonLoading(true)
                 createRole({
                     variables: {
                         name,
@@ -211,6 +218,11 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
                     .catch((e) => {
                         errorNotify(e.message)
                     })
+                    .finally(() => {
+                        setTimeout(() => {
+                            setModalButtonLoading(false)
+                        }, 500)
+                    })
             }
         }
 
@@ -226,6 +238,7 @@ const RoleFormModal = ({ role, isOpen, closeModal, refetch, view = false }: Prop
     return (
         <Modal
             title={formTitle}
+            loading={modalButtonLoading}
             submitLabel={submitLabel}
             isOpen={isOpen}
             handleClose={() => {

--- a/frontend/components/organisms/TagsAction/index.tsx
+++ b/frontend/components/organisms/TagsAction/index.tsx
@@ -19,6 +19,7 @@ const renderDeleteAction = (
     name: string,
     refetch: (isDelete?: boolean) => void
 ): JSX.Element => {
+    const [loading, setLoading] = useState(false)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     const [deleteTag] = useMutation(DELETE_TAG)
 
@@ -27,6 +28,7 @@ const renderDeleteAction = (
     }
 
     const handleSubmit = (): void => {
+        setLoading(true)
         deleteTag({ variables: { id } })
             .then(() => {
                 successNotify('Tag deleted.')
@@ -37,6 +39,9 @@ const renderDeleteAction = (
             })
             .finally(() => {
                 setShowDeleteModal(false)
+                setTimeout(() => {
+                    setLoading(false)
+                }, 500)
             })
     }
 
@@ -52,6 +57,7 @@ const renderDeleteAction = (
             </Button>
             <Modal
                 title="Delete Tag"
+                loading={loading}
                 isOpen={showDeleteModal}
                 handleClose={closeDeleteModal}
                 handleSubmit={handleSubmit}

--- a/frontend/components/organisms/TagsFormModal/index.tsx
+++ b/frontend/components/organisms/TagsFormModal/index.tsx
@@ -30,11 +30,13 @@ const TagsFormModal = ({
     refetchHandler,
 }: FormProps): JSX.Element => {
     const formTitle = initialData?.name ? 'Edit Tag' : 'Add Tag'
-    const [createTag] = useMutation(CREATE_TAG)
-    const [updateTag] = useMutation(UPDATE_TAG)
+    const [modalButtonLoading, setModalButtonLoading] = useState(false)
     const [formErrors, setFormErrors] = useState({ name: '', description: '' })
     const [tagName, setTagName] = useState(initialData?.name ?? '')
     const [tagDescription, setTagDescription] = useState(initialData?.description ?? '')
+
+    const [createTag] = useMutation(CREATE_TAG)
+    const [updateTag] = useMutation(UPDATE_TAG)
 
     useEffect(() => {
         setTagName(initialData?.name ?? '')
@@ -65,6 +67,7 @@ const TagsFormModal = ({
 
         if (valid) {
             if (formTitle === 'Add Tag') {
+                setModalButtonLoading(true)
                 createTag({
                     variables: {
                         name,
@@ -80,11 +83,16 @@ const TagsFormModal = ({
                     .catch((e) => {
                         errorNotify(e.message)
                     })
+                    .finally(() =>
+                        setTimeout(() => {
+                            setModalButtonLoading(false)
+                        }, 500)
+                    )
             } else {
                 if (initialData.name === name && initialData.description === description) {
-                    errorNotify('Tag is not updated!')
-                    closeModal()
+                    errorNotify('No changes were made!')
                 } else {
+                    setModalButtonLoading(true)
                     updateTag({
                         variables: {
                             id: initialData?.id,
@@ -100,6 +108,11 @@ const TagsFormModal = ({
                         .catch((e) => {
                             errorNotify(e.message)
                         })
+                        .finally(() =>
+                            setTimeout(() => {
+                                setModalButtonLoading(false)
+                            }, 500)
+                        )
                 }
             }
         }
@@ -116,6 +129,7 @@ const TagsFormModal = ({
         <Modal
             title={formTitle}
             submitLabel={formTitle}
+            loading={modalButtonLoading}
             isOpen={isOpen}
             handleClose={() => {
                 closeModal()

--- a/frontend/components/organisms/TeamsFormModal/index.tsx
+++ b/frontend/components/organisms/TeamsFormModal/index.tsx
@@ -46,6 +46,7 @@ const TeamsFormModal = ({
     })
     const formTitle = initialData?.title ? 'Edit Team' : 'Add Team'
 
+    const [modalButtonLoading, setModalButtonLoading] = useState(false)
     const [createTeam] = useMutation(CREATE_TEAM)
     const [updateTeam] = useMutation(UPDATE_TEAM)
 
@@ -108,10 +109,10 @@ const TeamsFormModal = ({
                     init_desc === teamDescription
                 ) {
                     errorNotify('No changes were made!')
-                    closeModal()
                     return
                 }
 
+                setModalButtonLoading(true)
                 updateTeam({
                     variables: {
                         id: initialData.id,
@@ -130,8 +131,12 @@ const TeamsFormModal = ({
                     .finally(() => {
                         closeModal()
                         reset()
+                        setTimeout(() => {
+                            setModalButtonLoading(false)
+                        }, 500)
                     })
             } else {
+                setModalButtonLoading(true)
                 createTeam({
                     variables: {
                         name: teamName,
@@ -149,6 +154,9 @@ const TeamsFormModal = ({
                     .finally(() => {
                         closeModal()
                         reset()
+                        setTimeout(() => {
+                            setModalButtonLoading(false)
+                        }, 500)
                     })
             }
         }
@@ -159,6 +167,7 @@ const TeamsFormModal = ({
         <Modal
             title={formTitle}
             submitLabel={formTitle}
+            loading={modalButtonLoading}
             isOpen={isOpen}
             handleClose={() => {
                 closeModal()

--- a/frontend/components/templates/Modal.tsx
+++ b/frontend/components/templates/Modal.tsx
@@ -1,13 +1,16 @@
 import Button from '@/components/atoms/Button'
 import { Dialog, Transition } from '@headlessui/react'
 import React, { Fragment } from 'react'
-import Icons from '../atoms/Icons'
+import Icons, { CustomIcons } from '../atoms/Icons'
+
+const { LoadingSpinner } = CustomIcons
 
 type ModalProps = {
     title: string
     children: JSX.Element | string
     submitLabel?: string
     isOpen: boolean
+    loading?: boolean
     handleSubmit?: () => void
     handleClose: () => void
     footerAlign?: 'left' | 'center' | 'right'
@@ -19,6 +22,7 @@ const Modal = ({
     children,
     submitLabel,
     isOpen,
+    loading = false,
     handleSubmit,
     handleClose,
     footerAlign = 'left',
@@ -92,15 +96,26 @@ const Modal = ({
                                             <Button
                                                 usage="stroke"
                                                 size="large"
-                                                additionalClass={`w-36 ${flipButtons}`}
+                                                isDisabled={loading}
+                                                additionalClass={`w-36 ${
+                                                    loading ? 'pointer-events-none' : ''
+                                                } ${flipButtons}`}
                                                 onClick={onClickSubmit}
                                             >
-                                                {submitLabel}
+                                                {loading ? (
+                                                    <LoadingSpinner additionalClass="flex justify-center" />
+                                                ) : (
+                                                    submitLabel
+                                                )}
                                             </Button>
                                             <Button
                                                 usage="grayed"
                                                 size="large"
+                                                isDisabled={loading}
                                                 onClick={handleClose}
+                                                additionalClass={`${
+                                                    loading ? 'pointer-events-none' : ''
+                                                }`}
                                             >
                                                 Cancel
                                             </Button>

--- a/frontend/pages/manage/roles/index.tsx
+++ b/frontend/pages/manage/roles/index.tsx
@@ -103,6 +103,7 @@ const DeleteRole = ({
     name: string
     refetch: () => void
 }): JSX.Element => {
+    const [loading, setLoading] = useState(false)
     const [showModal, setShowModal] = useState(false)
     const [deleteRole] = useMutation(DELETE_ROLE)
 
@@ -113,6 +114,7 @@ const DeleteRole = ({
             return
         }
 
+        setLoading(true)
         deleteRole({ variables: { id } })
             .then(() => {
                 successNotify('Role deleted successfully!')
@@ -122,6 +124,11 @@ const DeleteRole = ({
             .catch(() => {
                 errorNotify('There was an error removing the role!')
             })
+            .finally(() =>
+                setTimeout(() => {
+                    setLoading(false)
+                }, 500)
+            )
     }
 
     return (
@@ -136,6 +143,7 @@ const DeleteRole = ({
             </Button>
             <Modal
                 title="Delete Role"
+                loading={loading}
                 isOpen={showModal}
                 handleClose={() => {
                     setShowModal(false)

--- a/frontend/pages/manage/teams/index.tsx
+++ b/frontend/pages/manage/teams/index.tsx
@@ -216,10 +216,12 @@ const AdminTeams = (): JSX.Element => {
         name: string
         refetch: () => void
     }): JSX.Element => {
+        const [loading, setLoading] = useState(false)
         const [showModal, setShowModal] = useState(false)
         const [deleteRole] = useMutation(DELETE_TEAM)
 
         const onSubmit = (): void => {
+            setLoading(true)
             deleteRole({ variables: { id } })
                 .then(() => {
                     successNotify('Team successfully deleted')
@@ -230,6 +232,9 @@ const AdminTeams = (): JSX.Element => {
                 })
                 .finally(() => {
                     setShowModal(false)
+                    setTimeout(() => {
+                        setLoading(false)
+                    }, 500)
                 })
         }
 
@@ -245,6 +250,7 @@ const AdminTeams = (): JSX.Element => {
                 </Button>
                 <Modal
                     title="Delete Team"
+                    loading={loading}
                     isOpen={showModal}
                     handleClose={() => {
                         setShowModal(false)


### PR DESCRIPTION
## Backlog Link
https://framgiaph.backlog.com/view/SUN_OVERFLOW-461

## Commands
Go to `Tags` page then try to add/edit/delete items

## Pre-conditions

## Expected Output
- [x] Modal buttons should be disabled during async requests

## Notes
- I also updated admin teams and admin roles

## Screenshots
[Button State.webm](https://user-images.githubusercontent.com/111732984/236728242-8ae85054-f59b-490e-9df2-5bfc6d8dfd33.webm)
